### PR TITLE
Add definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ var options = {
     },
   },
   apis: ['./routes.js'], // Path to the API docs
+  models:['./user.js'] //Path to the model definitions
 };
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format

--- a/example/app.js
+++ b/example/app.js
@@ -34,7 +34,7 @@ var swaggerDefinition = {
 var options = {
   swaggerDefinition: swaggerDefinition, // Import swaggerDefinitions
   apis: ['./example/routes.js'], // Path to the API docs
-  models: ['./example/user.js']
+  models: ['./example/user.js'] // Path to the model definitions
 };
 
 

--- a/example/app.js
+++ b/example/app.js
@@ -34,6 +34,7 @@ var swaggerDefinition = {
 var options = {
   swaggerDefinition: swaggerDefinition, // Import swaggerDefinitions
   apis: ['./example/routes.js'], // Path to the API docs
+  models: ['./example/user.js']
 };
 
 

--- a/example/app.js
+++ b/example/app.js
@@ -34,7 +34,7 @@ var swaggerDefinition = {
 var options = {
   swaggerDefinition: swaggerDefinition, // Import swaggerDefinitions
   apis: ['./example/routes.js'], // Path to the API docs
-  models: ['./example/user.js'] // Path to the model definitions
+  models: ['./example/user.js'], // Path to the model definitions
 };
 
 

--- a/example/routes.js
+++ b/example/routes.js
@@ -55,6 +55,8 @@ module.exports.setup = function(app) {
    *     responses:
    *       200:
    *         description: users
+   *         schema:
+   *            $ref: '#/definitions/User'
    */
   app.get('/users', function(req, res) {
     res.json({

--- a/example/user.js
+++ b/example/user.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * @swagger
+ *  User:
+ *    properties:
+ *      username:
+ *        description: The users alias
+ */
+
+module.exports = {
+    username:'jsmith'
+};

--- a/example/user.js
+++ b/example/user.js
@@ -9,5 +9,5 @@
  */
 
 module.exports = {
-    username:'jsmith'
+  username: 'jsmith',
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,23 +87,48 @@ function objectMerge(obj1, obj2) {
 }
 
 /**
- * Adds the data in the Swagger JSDoc comments to the swagger object.
+ * Adds the data in the Swagger JSDoc comments to the
+ * swagger object, under the given key.
  * @function
  * @param {object} swaggerObject - Swagger object which will be written to
  * @param {array} swaggerJsDocComments - JSDoc comments tagged with '@swagger'
+ * @param {string} key - The key that the comments should be added
+ * under in the swagger object.
  */
-function addDataToSwaggerObject(swaggerObject, swaggerJsDocComments) {
+function addDataToSwaggerObject(swaggerObject, swaggerJsDocComments, key) {
+  if (typeof swaggerObject[key] === 'undefined') {
+    swaggerObject[key] = {};
+  }
   for (var i = 0; i < swaggerJsDocComments.length; i = i + 1) {
     var pathObject = swaggerJsDocComments[i];
     var propertyNames = Object.getOwnPropertyNames(pathObject);
 
     for (var j = 0; j < propertyNames.length; j = j + 1) {
       var propertyName = propertyNames[j];
-      swaggerObject.paths[propertyName] = objectMerge(
-        swaggerObject.paths[propertyName], pathObject[propertyName]
+      swaggerObject[key][propertyName] = objectMerge(
+        swaggerObject[key][propertyName], pathObject[propertyName]
       );
     }
   }
+}
+
+/**
+ * Loads swagger documentation for a given key
+ * @function
+ * @param {object} swaggerObject - Current swaggerObject.
+ * @param {array} paths - The paths of the documents to
+ * parse and load under the key.
+ * @param {string} key - The key for the documentation
+ * to be loaded under.
+ * @returns {object} Swagger spec
+ */
+function loadSwaggerDocsForKey(swaggerObject, paths, key) {
+  for (var i = 0; i < paths.length; i = i + 1) {
+    var jsDocComments = parseApiFile(paths[i]);
+    var swaggerJsDocComments = filterJsDocComments(jsDocComments);
+    addDataToSwaggerObject(swaggerObject, swaggerJsDocComments, key);
+  }
+  return swaggerObject;
 }
 
 /**
@@ -129,11 +154,12 @@ module.exports = function(options) {
   swaggerObject.swagger = '2.0';
   swaggerObject.paths = {};
 
-  // Parse the documentation in the APIs array.
-  for (var i = 0; i < options.apis.length; i = i + 1) {
-    var jsDocComments = parseApiFile(options.apis[i]);
-    var swaggerJsDocComments = filterJsDocComments(jsDocComments);
-    addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
+  if (typeof options.apis !== 'undefined') {
+    loadSwaggerDocsForKey(swaggerObject, options.apis, 'paths');
+  }
+
+  if (typeof options.models !== 'undefined') {
+    loadSwaggerDocsForKey(swaggerObject, options.models, 'definitions');
   }
 
   parser.parse(swaggerObject, function(err, api) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,9 +154,7 @@ module.exports = function(options) {
   swaggerObject.swagger = '2.0';
   swaggerObject.paths = {};
 
-  if (typeof options.apis !== 'undefined') {
-    loadSwaggerDocsForKey(swaggerObject, options.apis, 'paths');
-  }
+  loadSwaggerDocsForKey(swaggerObject, options.apis, 'paths');
 
   if (typeof options.models !== 'undefined') {
     loadSwaggerDocsForKey(swaggerObject, options.models, 'definitions');

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -1,5 +1,6 @@
 {
-  "info": {
+  "info":
+  {
     "title": "Hello World",
     "version": "1.0.0",
     "description": "A sample API"
@@ -7,24 +8,34 @@
   "host": "localhost:3000",
   "basePath": "/",
   "swagger": "2.0",
-  "paths": {
-    "/": {
-      "get": {
+  "paths":
+  {
+    "/":
+    {
+      "get":
+      {
         "description": "Returns the homepage",
-        "responses": {
-          "200": {
+        "responses":
+        {
+          "200":
+          {
             "description": "hello world"
           }
         }
       }
     },
-    "/login": {
-      "post": {
+    "/login":
+    {
+      "post":
+      {
         "description": "Login to the application",
-        "produces": [
+        "produces":
+        [
           "application/json"
         ],
-        "parameters": [
+        "parameters":
+        [
+
           {
             "name": "username",
             "description": "Username to use for login.",
@@ -32,6 +43,7 @@
             "required": true,
             "type": "string"
           },
+
           {
             "name": "password",
             "description": "User's password.",
@@ -40,31 +52,46 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
+        "responses":
+        {
+          "200":
+          {
             "description": "login"
           }
         }
       }
     },
-    "/users": {
-      "get": {
+    "/users":
+    {
+      "get":
+      {
         "description": "Returns users",
-        "produces": [
+        "produces":
+        [
           "application/json"
         ],
-        "responses": {
-          "200": {
-            "description": "users"
+        "responses":
+        {
+          "200":
+          {
+            "description": "users",
+            "schema":
+            {
+              "$ref": "#/definitions/User"
+            }
           }
         }
       },
-      "post": {
+      "post":
+      {
         "description": "Returns users",
-        "produces": [
+        "produces":
+        [
           "application/json"
         ],
-        "parameters": [
+        "parameters":
+        [
+
           {
             "name": "username",
             "description": "username for user",
@@ -73,10 +100,25 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
+        "responses":
+        {
+          "200":
+          {
             "description": "users"
           }
+        }
+      }
+    }
+  },
+  "definitions":
+  {
+    "User":
+    {
+      "properties":
+      {
+        "username":
+        {
+          "description": "The users alias"
         }
       }
     }


### PR DESCRIPTION
I noticed that I was unable to create definition objects for the docs. I modified the code a bit to allow for a model option that will load @swagger comments into the definitions configuration in the swagger docs. This implementation may have some limitations, if you try to load the same file into both apis and models then all @swagger comments will be included in both the apis and definitions. I am un-sure how/if we could/want to account for this edge case without major changes to the api.  Suggestions welcome. Thanks for the awesome package!