### PR TITLE
Removed filename restriction for "*.js"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,12 +18,6 @@ var parser = require('swagger-parser');
  * @requires doctrine
  */
 function parseApiFile(file) {
-  var fileExtension = path.extname(file);
-
-  /* istanbul ignore if */
-  if (fileExtension !== '.js') {
-    throw new Error('Unsupported extension \'' + fileExtension + '\'.');
-  }
 
   var jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   var fileContent = fs.readFileSync(file, { encoding: 'utf8' });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 
 // Dependencies
 var fs = require('fs');
-var path = require('path');
 var doctrine = require('doctrine');
 var jsYaml = require('js-yaml');
 var parser = require('swagger-parser');


### PR DESCRIPTION
I'd like to use swagger-jsdoc together with a PHP-Project. Since the documentation style is similar in many programming languages, I removed the restriction for the file extension "*.js".
