### PR TITLE
Include .yaml, and able to define responses, parameters and securityDefinitions

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -58,6 +58,6 @@
     "prototypejs": false,
     "maxparams": 4,
     "maxdepth": 4,
-    "maxstatements": 18,
+    "maxstatements": 19,
     "maxcomplexity": 8
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -58,6 +58,6 @@
     "prototypejs": false,
     "maxparams": 4,
     "maxdepth": 4,
-    "maxstatements": 15,
-    "maxcomplexity": 6
+    "maxstatements": 18,
+    "maxcomplexity": 8
 }

--- a/example/app.js
+++ b/example/app.js
@@ -41,7 +41,7 @@ var options = {
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
 var swaggerSpec = swaggerJSDoc(options);
-console.log(require('util').inspect(swaggerSpec, {depth: 5}));
+
 // Serve swagger docs the way you like (Recommendation: swagger-tools)
 app.get('/api-docs.json', function(req, res) {
   res.setHeader('Content-Type', 'application/json');

--- a/example/app.js
+++ b/example/app.js
@@ -40,7 +40,6 @@ var options = {
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
 var swaggerSpec = swaggerJSDoc(options);
 
-
 // Serve swagger docs the way you like (Recommendation: swagger-tools)
 app.get('/api-docs.json', function(req, res) {
   res.setHeader('Content-Type', 'application/json');

--- a/example/app.js
+++ b/example/app.js
@@ -32,14 +32,16 @@ var swaggerDefinition = {
 
 // Options for the swagger docs
 var options = {
-  swaggerDefinition: swaggerDefinition, // Import swaggerDefinitions
-  apis: ['./example/routes.js'], // Path to the API docs
+  // Import swaggerDefinitions
+  swaggerDefinition: swaggerDefinition,
+  // Path to the API docs
+  apis: ['./example/routes.js', './example/parameters.yaml'],
 };
 
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
 var swaggerSpec = swaggerJSDoc(options);
-
+console.log(require('util').inspect(swaggerSpec, {depth: 5}));
 // Serve swagger docs the way you like (Recommendation: swagger-tools)
 app.get('/api-docs.json', function(req, res) {
   res.setHeader('Content-Type', 'application/json');

--- a/example/parameters.yaml
+++ b/example/parameters.yaml
@@ -1,0 +1,7 @@
+parameter:
+  username:
+    name: username
+    description: Username to use for login.
+    in: formData
+    required: true
+    type: string

--- a/example/routes.js
+++ b/example/routes.js
@@ -3,7 +3,16 @@
 
 // Sets up the routes.
 module.exports.setup = function(app) {
-
+  /**
+   * @swagger
+   * parameter:
+   *   username:
+   *     name: username
+   *     description: Username to use for login.
+   *     in: formData
+   *     required: true
+   *     type: string
+   */
 
   /**
    * @swagger
@@ -40,11 +49,7 @@ module.exports.setup = function(app) {
    *     produces:
    *       - application/json
    *     parameters:
-   *       - name: username
-   *         description: Username to use for login.
-   *         in: formData
-   *         required: true
-   *         type: string
+   *       - $ref: '#/parameters/username'
    *       - name: password
    *         description: User's password.
    *         in: formData

--- a/example/routes.js
+++ b/example/routes.js
@@ -3,16 +3,6 @@
 
 // Sets up the routes.
 module.exports.setup = function(app) {
-  /**
-   * @swagger
-   * parameter:
-   *   username:
-   *     name: username
-   *     description: Username to use for login.
-   *     in: formData
-   *     required: true
-   *     type: string
-   */
 
   /**
    * @swagger
@@ -91,11 +81,7 @@ module.exports.setup = function(app) {
    *     produces:
    *       - application/json
    *     parameters:
-   *       - name: username
-   *         description: username for user
-   *         in: formData
-   *         required: true
-   *         type: string
+   *       - $ref: '#/parameters/username'
    *     responses:
    *       200:
    *         description: users

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,12 +92,17 @@ function addDataToSwaggerObject(swaggerObject, swaggerJsDocComments) {
     for (var j = 0; j < propertyNames.length; j = j + 1) {
       var propertyName = propertyNames[j];
       switch (propertyName) {
+        case 'securityDefinition':
+        case 'response':
+        case 'parameter':
         case 'definition': {
+          var keyName = propertyName + 's';
+          if(!swaggerObject[keyName]) swaggerObject[keyName] = {};
           var definitionNames = Object
             .getOwnPropertyNames(pathObject[propertyName]);
           for (var k = 0; k < definitionNames.length; k = k + 1) {
             var definitionName = definitionNames[k];
-            swaggerObject.definitions[definitionName] =
+            swaggerObject[keyName][definitionName] =
               pathObject[propertyName][definitionName];
           }
           break;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,33 +4,42 @@
 
 // Dependencies
 var fs = require('fs');
+var path = require('path');
 var doctrine = require('doctrine');
 var jsYaml = require('js-yaml');
 var parser = require('swagger-parser');
-
 
 /**
  * Parses the provided API file for JSDoc comments.
  * @function
  * @param {string} file - File to be parsed
- * @returns {array} JSDoc comments
+ * @returns {{jsdoc: array, yaml: array}} JSDoc comments and Yaml files
  * @requires doctrine
  */
 function parseApiFile(file) {
 
   var jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   var fileContent = fs.readFileSync(file, { encoding: 'utf8' });
-  var regexResults = fileContent.match(jsDocRegex);
-
+  var ext = path.parse(file).ext;
+  var yaml = [];
   var jsDocComments = [];
-  if (regexResults) {
-    for (var i = 0; i < regexResults.length; i = i + 1) {
-      var jsDocComment = doctrine.parse(regexResults[i], { unwrap: true });
-      jsDocComments.push(jsDocComment);
+
+  if (ext === '.yaml' || ext === '.yml') {
+    yaml.push(jsYaml.safeLoad(fileContent));
+  } else {
+    var regexResults = fileContent.match(jsDocRegex);
+    if (regexResults) {
+      for (var i = 0; i < regexResults.length; i = i + 1) {
+        var jsDocComment = doctrine.parse(regexResults[i], { unwrap: true });
+        jsDocComments.push(jsDocComment);
+      }
     }
   }
 
-  return jsDocComments;
+  return {
+    yaml: yaml,
+    jsdoc: jsDocComments,
+  };
 }
 
 
@@ -80,14 +89,15 @@ function objectMerge(obj1, obj2) {
 }
 
 /**
- * Adds the data in the Swagger JSDoc comments to the swagger object.
+ * Adds the data in to the swagger object.
  * @function
  * @param {object} swaggerObject - Swagger object which will be written to
- * @param {array} swaggerJsDocComments - JSDoc comments tagged with '@swagger'
+ * @param {object[]} data - objects of parsed swagger data from yaml or jsDoc
+ *                          comments
  */
-function addDataToSwaggerObject(swaggerObject, swaggerJsDocComments) {
-  for (var i = 0; i < swaggerJsDocComments.length; i = i + 1) {
-    var pathObject = swaggerJsDocComments[i];
+function addDataToSwaggerObject(swaggerObject, data) {
+  for (var i = 0; i < data.length; i = i + 1) {
+    var pathObject = data[i];
     var propertyNames = Object.getOwnPropertyNames(pathObject);
     for (var j = 0; j < propertyNames.length; j = j + 1) {
       var propertyName = propertyNames[j];
@@ -145,8 +155,9 @@ module.exports = function(options) {
 
   // Parse the documentation in the APIs array.
   for (var i = 0; i < options.apis.length; i = i + 1) {
-    var jsDocComments = parseApiFile(options.apis[i]);
-    var swaggerJsDocComments = filterJsDocComments(jsDocComments);
+    var files = parseApiFile(options.apis[i]);
+    var swaggerJsDocComments = filterJsDocComments(files.jsdoc);
+    addDataToSwaggerObject(swaggerObject, files.yaml);
     addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,6 @@ function addDataToSwaggerObject(swaggerObject, swaggerJsDocComments) {
         case 'parameter':
         case 'definition': {
           var keyName = propertyName + 's';
-          if(!swaggerObject[keyName]) swaggerObject[keyName] = {};
           var definitionNames = Object
             .getOwnPropertyNames(pathObject[propertyName]);
           for (var k = 0; k < definitionNames.length; k = k + 1) {
@@ -140,6 +139,9 @@ module.exports = function(options) {
   swaggerObject.swagger = '2.0';
   swaggerObject.paths = {};
   swaggerObject.definitions = {};
+  swaggerObject.responses = {};
+  swaggerObject.parameters = {};
+  swaggerObject.securityDefinitions = {};
 
   // Parse the documentation in the APIs array.
   for (var i = 0; i < options.apis.length; i = i + 1) {

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -26,11 +26,7 @@
         ],
         "parameters": [
           {
-            "name": "username",
-            "description": "Username to use for login.",
-            "in": "formData",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/username"
           },
           {
             "name": "password",
@@ -100,5 +96,16 @@
         }
       }
     }
-  }
+  },
+  "responses": {},
+  "parameters": {
+    "username": {
+      "name": "username",
+      "description": "Username to use for login.",
+      "in": "formData",
+      "required": true,
+      "type": "string"
+    }
+  },
+  "securityDefinitions": {}
 }

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -66,11 +66,7 @@
         ],
         "parameters": [
           {
-            "name": "username",
-            "description": "username for user",
-            "in": "formData",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/username"
           }
         ],
         "responses": {


### PR DESCRIPTION
Document responses, parameters and securityDefinitions in a similar fashion as for definitions.
Able to include directly yaml files as apis (that will be merged with the jsdoc comments).
Tests included, but increased max statements from 15 to 18 and max complexity from 6 to 8 to pass the jshint test.