### PR TITLE
Prevent node.js < 0.12 from installing newer versions of swagger-jsdo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "swagger-jsdoc",
   "version": "1.2.0",
   "description": "Generates swagger doc based on JSDoc",
+  "engine": "node >= 0.12",
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover _mocha --report html && istanbul check-coverage --statement 95",


### PR DESCRIPTION
…c, which don't work on older versions of node.js. Solves #16.

Please note that to prevent problems, swagger-jsdoc 1.2.0 needs to be removed from the npmjs repository as well.