### PR TITLE
use path.extname instead of path.parse

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function parseApiFile(file) {
 
   var jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   var fileContent = fs.readFileSync(file, { encoding: 'utf8' });
-  var ext = path.parse(file).ext;
+  var ext = path.extname(file);
   var yaml = [];
   var jsDocComments = [];
 


### PR DESCRIPTION
path.parse is not present in node 0.10.x
this change allows to use swagger-jsdoc with node 0.10.x