### PR TITLE
[WIP] options.api allows glob strings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -58,6 +58,6 @@
     "prototypejs": false,
     "maxparams": 4,
     "maxdepth": 4,
-    "maxstatements": 19,
+    "maxstatements": 20,
     "maxcomplexity": 8
 }

--- a/example/app.js
+++ b/example/app.js
@@ -5,6 +5,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var routes = require('./routes');
+var routes2 = require('./routes2');
 var swaggerJSDoc = require('../');
 
 
@@ -35,7 +36,7 @@ var options = {
   // Import swaggerDefinitions
   swaggerDefinition: swaggerDefinition,
   // Path to the API docs
-  apis: ['./example/routes.js', './example/parameters.yaml'],
+  apis: ['./example/routes*.js', './example/parameters.yaml'],
 };
 
 
@@ -51,7 +52,7 @@ app.get('/api-docs.json', function(req, res) {
 
 // Set up the routes
 routes.setup(app);
-
+routes2.setup(app);
 
 // Expose app
 exports = module.exports = app;

--- a/example/routes2.js
+++ b/example/routes2.js
@@ -1,0 +1,32 @@
+'use strict';
+
+
+module.exports.setup = function(app) {
+
+  /**
+   * @swagger
+   * /hello:
+   *   get:
+   *     description: Returns the homepage
+   *     responses:
+   *       200:
+   *         description: hello world
+   */
+  app.get('/hello', function(req, res) {
+    res.send('Hello World (Version 2)!');
+  });
+
+  /**
+   * @swagger
+   * definition:
+   *   Login2:
+   *     required:
+   *       - username
+   *       - password
+   *     properties:
+   *       username:
+   *         type: string
+   *       password:
+   *         type: string
+   */
+};

--- a/example/routes2.js
+++ b/example/routes2.js
@@ -2,7 +2,6 @@
 
 
 module.exports.setup = function(app) {
-
   /**
    * @swagger
    * /hello:
@@ -15,18 +14,4 @@ module.exports.setup = function(app) {
   app.get('/hello', function(req, res) {
     res.send('Hello World (Version 2)!');
   });
-
-  /**
-   * @swagger
-   * definition:
-   *   Login2:
-   *     required:
-   *       - username
-   *       - password
-   *     properties:
-   *       username:
-   *         type: string
-   *       password:
-   *         type: string
-   */
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
 
 // Dependencies
 var fs = require('fs');
+var glob = require('glob');
 var path = require('path');
 var doctrine = require('doctrine');
 var jsYaml = require('js-yaml');
@@ -17,7 +18,6 @@ var parser = require('swagger-parser');
  * @requires doctrine
  */
 function parseApiFile(file) {
-
   var jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   var fileContent = fs.readFileSync(file, { encoding: 'utf8' });
   var ext = path.extname(file);
@@ -153,9 +153,15 @@ module.exports = function(options) {
   swaggerObject.parameters = {};
   swaggerObject.securityDefinitions = {};
 
+  // Build up the array of file names
+  var apiPaths = options.apis.reduce(function(acc, file) {
+    var globFiles = glob.sync(file);
+    return acc.concat(globFiles);
+  }, []);
+
   // Parse the documentation in the APIs array.
-  for (var i = 0; i < options.apis.length; i = i + 1) {
-    var files = parseApiFile(options.apis[i]);
+  for (var i = 0; i < apiPaths.length; i = i + 1) {
+    var files = parseApiFile(apiPaths[i]);
     var swaggerJsDocComments = filterJsDocComments(files.jsdoc);
     addDataToSwaggerObject(swaggerObject, files.yaml);
     addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
@@ -166,6 +172,5 @@ module.exports = function(options) {
       swaggerObject = api;
     }
   });
-
   return swaggerObject;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,20 @@ function addDataToSwaggerObject(swaggerObject, data) {
 }
 
 /**
+ * Converts an array of globs to full paths
+ * @function
+ * @param {array} globs - Array of globs and/or normal paths
+ * @return {array} Array of fully-qualified paths
+ * @requires glob
+ */
+function convertGlobPaths(globs) {
+  return globs.reduce(function(acc, globString) {
+    var globFiles = glob.sync(globString);
+    return acc.concat(globFiles);
+  }, []);
+}
+
+/**
  * Generates the swagger spec
  * @function
  * @param {object} options - Configuration options
@@ -153,11 +167,7 @@ module.exports = function(options) {
   swaggerObject.parameters = {};
   swaggerObject.securityDefinitions = {};
 
-  // Build up the array of file names
-  var apiPaths = options.apis.reduce(function(acc, file) {
-    var globFiles = glob.sync(file);
-    return acc.concat(globFiles);
-  }, []);
+  var apiPaths = convertGlobPaths(options.apis);
 
   // Parse the documentation in the APIs array.
   for (var i = 0; i < apiPaths.length; i = i + 1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-jsdoc",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Generates swagger doc based on JSDoc",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/Surnet/swagger-jsdoc",
   "dependencies": {
     "doctrine": "^1.2.0",
+    "glob": "^7.0.3",
     "js-yaml": "^3.5.3",
     "swagger-parser": "^3.4.0"
   },

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -75,10 +75,34 @@
           }
         }
       }
+    },
+    "/hello": {
+      "get": {
+        "description": "Returns the homepage",
+        "responses": {
+          "200": {
+            "description": "hello world"
+          }
+        }
+      }
     }
   },
   "definitions": {
     "Login": {
+      "required": [
+        "username",
+        "password"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "Login2": {
       "required": [
         "username",
         "password"

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -101,20 +101,6 @@
           "type": "string"
         }
       }
-    },
-    "Login2": {
-      "required": [
-        "username",
-        "password"
-      ],
-      "properties": {
-        "username": {
-          "type": "string"
-        },
-        "password": {
-          "type": "string"
-        }
-      }
     }
   },
   "responses": {},


### PR DESCRIPTION
Re: #19

This is my first pass at the glob feature. Since the `glob` library handles non-glob strings perfectly fine, I simply map-reduce the whole `apis` array through glob, and then pass the resulting array into the for-loop.

Tests still pass, but I'm not sure if a spec was written for this part of the code.