### PR TITLE
Don't override user provided swagger definition options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -145,6 +145,33 @@ function convertGlobPaths(globs) {
 }
 
 /**
+ * Populates any missing required properties on a Swagger object
+ * @function
+ * @param {object} swaggerObject - Swagger Object
+ * @returns {object} Swagger Object with required properties set
+ */
+function populateMissingProperties(swaggerObject) {
+  if (!swaggerObject.hasOwnProperty('paths')) {
+    swaggerObject.paths = {};
+  }
+  if (!swaggerObject.hasOwnProperty('definitions')) {
+    swaggerObject.definitions = {};
+  }
+  if (!swaggerObject.hasOwnProperty('responses')) {
+    swaggerObject.responses = {};
+  }
+  if (!swaggerObject.hasOwnProperty('parameters')) {
+    swaggerObject.parameters = {};
+  }
+  if (!swaggerObject.hasOwnProperty('securityDefinitions')) {
+    swaggerObject.securityDefinitions = {};
+  }
+  if (!swaggerObject.hasOwnProperty('tags')) {
+    swaggerObject.tags = [];
+  }
+}
+
+/**
  * Generates the swagger spec
  * @function
  * @param {object} options - Configuration options
@@ -165,24 +192,7 @@ module.exports = function(options) {
   var swaggerObject = [];
   swaggerObject = options.swaggerDefinition;
   swaggerObject.swagger = '2.0';
-  if (!swaggerObject.hasOwnProperty('paths')) {
-    swaggerObject.paths = {};
-  }
-  if (!swaggerObject.hasOwnProperty('definitions')) {
-    swaggerObject.definitions = {};
-  }
-  if (!swaggerObject.hasOwnProperty('responses')) {
-    swaggerObject.responses = {};
-  }
-  if (!swaggerObject.hasOwnProperty('parameters')) {
-    swaggerObject.parameters = {};
-  }
-  if (!swaggerObject.hasOwnProperty('securityDefinitions')) {
-    swaggerObject.securityDefinitions = {};
-  }
-  if (!swaggerObject.hasOwnProperty('tags')) {
-    swaggerObject.tags = [];
-  }
+  populateMissingProperties(swaggerObject);
 
   var apiPaths = convertGlobPaths(options.apis);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ function addDataToSwaggerObject(swaggerObject, data) {
       var propertyName = propertyNames[j];
       var keyName = propertyName + 's';
       switch (propertyName) {
-        case 'securityDefinitions':
+        case 'securityDefinition':
         case 'response':
         case 'parameter':
         case 'definition': {
@@ -165,12 +165,24 @@ module.exports = function(options) {
   var swaggerObject = [];
   swaggerObject = options.swaggerDefinition;
   swaggerObject.swagger = '2.0';
-  swaggerObject.paths = {};
-  swaggerObject.definitions = {};
-  swaggerObject.responses = {};
-  swaggerObject.parameters = {};
-  swaggerObject.securityDefinitions = {};
-  swaggerObject.tags = [];
+  if (!swaggerObject.hasOwnProperty('paths')) {
+    swaggerObject.paths = {};
+  }
+  if (!swaggerObject.hasOwnProperty('definitions')) {
+    swaggerObject.definitions = {};
+  }
+  if (!swaggerObject.hasOwnProperty('responses')) {
+    swaggerObject.responses = {};
+  }
+  if (!swaggerObject.hasOwnProperty('parameters')) {
+    swaggerObject.parameters = {};
+  }
+  if (!swaggerObject.hasOwnProperty('securityDefinitions')) {
+    swaggerObject.securityDefinitions = {};
+  }
+  if (!swaggerObject.hasOwnProperty('tags')) {
+    swaggerObject.tags = [];
+  }
 
   var apiPaths = convertGlobPaths(options.apis);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ function addDataToSwaggerObject(swaggerObject, data) {
       var propertyName = propertyNames[j];
       var keyName = propertyName + 's';
       switch (propertyName) {
-        case 'securityDefinition':
+        case 'securityDefinitions':
         case 'response':
         case 'parameter':
         case 'definition': {

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,8 +173,6 @@ module.exports = function(options) {
   swaggerObject = options.swaggerDefinition;
   swaggerObject.swagger = '2.0';
 
-  populateMissingProperties(swaggerObject);
-
   swaggerObject.paths = swaggerObject.paths || {};
   swaggerObject.definitions = swaggerObject.definitions || {};
   swaggerObject.responses = swaggerObject.responses || {};


### PR DESCRIPTION
Only setting properties on the swaggerObject that do not exist to prevent overwriting user specified properties.