### PR TITLE
support multiple tags as an array and in definition

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -57,7 +57,7 @@
     "mootools": false,
     "prototypejs": false,
     "maxparams": 4,
-    "maxdepth": 4,
+    "maxdepth": 5,
     "maxstatements": 25,
-    "maxcomplexity": 9
+    "maxcomplexity": 11
 }

--- a/example/routes.js
+++ b/example/routes.js
@@ -78,7 +78,8 @@ module.exports.setup = function(app) {
    * /users:
    *   get:
    *     description: Returns users
-   *     tag: [Users]
+   *     tag:
+   *      - Users
    *     produces:
    *      - application/json
    *     responses:

--- a/example/routes.js
+++ b/example/routes.js
@@ -40,10 +40,19 @@ module.exports.setup = function(app) {
 
   /**
    * @swagger
+   * tag:
+   *   - name: Login
+   *     description: Login
+   *   - name: Accounts
+   *     description: Accounts
+   */
+
+  /**
+   * @swagger
    * /login:
    *   post:
    *     description: Login to the application
-   *     tag: [Users]
+   *     tag: [Users, Login]
    *     produces:
    *       - application/json
    *     parameters:

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,7 +117,14 @@ function addDataToSwaggerObject(swaggerObject, data) {
           break;
         }
         case 'tag': {
-          swaggerObject[keyName].push(pathObject[propertyName]);
+          var tag = pathObject[propertyName];
+          if (Array.isArray(tag)) {
+            for (var t = 0; t < tag.length; t = t + 1) {
+              swaggerObject[keyName].push(tag[t]);
+            }
+          } else {
+            swaggerObject[keyName].push(tag);
+          }
           break;
         }
         default: {
@@ -170,7 +177,7 @@ module.exports = function(options) {
   swaggerObject.responses = {};
   swaggerObject.parameters = {};
   swaggerObject.securityDefinitions = {};
-  swaggerObject.tags = [];
+  swaggerObject.tags = swaggerObject.tags || [];
 
   var apiPaths = convertGlobPaths(options.apis);
 

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -22,7 +22,8 @@
       "post": {
         "description": "Login to the application",
         "tag": [
-          "Users"
+          "Users",
+          "Login"
         ],
         "produces": [
           "application/json"
@@ -127,6 +128,14 @@
     {
       "name": "Users",
       "description": "User management and login"
+    },
+    {
+      "name": "Login",
+      "description": "Login"
+    },
+    {
+      "name": "Accounts",
+      "description": "Accounts"
     }
   ]
 }


### PR DESCRIPTION
Allow to set multiple tags in jsdoc with as an array
It will allow definition of tags in swagger definition and will merge with others in the jsdoc.