### PR TITLE
Revising input swagger properties

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 // Dependencies
 var express = require('express');
 var bodyParser = require('body-parser');
@@ -8,14 +7,12 @@ var routes = require('./routes');
 var routes2 = require('./routes2');
 var swaggerJSDoc = require('../');
 
-
 // Initialize express
 var app = express();
 app.use(bodyParser.json()); // To support JSON-encoded bodies
 app.use(bodyParser.urlencoded({ // To support URL-encoded bodies
   extended: true,
 }));
-
 
 // Swagger definition
 // You can set every attribute except paths and swagger
@@ -30,7 +27,6 @@ var swaggerDefinition = {
   basePath: '/', // Base path (optional)
 };
 
-
 // Options for the swagger docs
 var options = {
   // Import swaggerDefinitions
@@ -38,7 +34,6 @@ var options = {
   // Path to the API docs
   apis: ['./example/routes*.js', './example/parameters.yaml'],
 };
-
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
 var swaggerSpec = swaggerJSDoc(options);
@@ -49,7 +44,6 @@ app.get('/api-docs.json', function(req, res) {
   res.send(swaggerSpec);
 });
 
-
 // Set up the routes
 routes.setup(app);
 routes2.setup(app);
@@ -57,9 +51,8 @@ routes2.setup(app);
 // Expose app
 exports = module.exports = app;
 
-
 // Start the server
-var server = app.listen(3000, function() {
+var server = app.listen(3000, function startExpressServer() {
   var host = server.address().address;
   var port = server.address().port;
 

--- a/example/parameters.yaml
+++ b/example/parameters.yaml
@@ -1,4 +1,4 @@
-parameter:
+parameters:
   username:
     name: username
     description: Username to use for login.

--- a/example/routes.js
+++ b/example/routes.js
@@ -19,7 +19,7 @@ module.exports.setup = function(app) {
 
   /**
    * @swagger
-   * definition:
+   * definitions:
    *   Login:
    *     required:
    *       - username

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,15 @@ module.exports = function(options) {
   for (var i = 0; i < apiPaths.length; i = i + 1) {
     var files = parseApiFile(apiPaths[i]);
     var swaggerJsDocComments = filterJsDocComments(files.jsdoc);
+
+    var problems = swaggerHelpers.findDeprecated([files, swaggerJsDocComments]);
+    // Report a warning in case potential problems encountered.
+    if (problems.length > 0) {
+      console.warn('You are using properties to be deprecated in v2.0.0');
+      console.warn('Please update to align with the swagger v2.0 spec.');
+      console.warn(problems);
+    }
+
     swaggerHelpers.addDataToSwaggerObject(swaggerObject, files.yaml);
     swaggerHelpers.addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 /** @module index */
 'use strict';
 
-
 // Dependencies
 var fs = require('fs');
 var glob = require('glob');

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var path = require('path');
 var doctrine = require('doctrine');
 var jsYaml = require('js-yaml');
 var parser = require('swagger-parser');
+var swaggerHelpers = require('./swagger-helpers');
 
 /**
  * Parses the provided API file for JSDoc comments.
@@ -42,7 +43,6 @@ function parseApiFile(file) {
   };
 }
 
-
 /**
  * Filters JSDoc comments for those tagged with '@swagger'
  * @function
@@ -64,115 +64,6 @@ function filterJsDocComments(jsDocComments) {
   }
 
   return swaggerJsDocComments;
-}
-
-/**
- * Merges two objects
- * @function
- * @param {object} obj1 - Object 1
- * @param {object} obj2 - Object 2
- * @returns {object} Merged Object
- */
-function objectMerge(obj1, obj2) {
-  var obj3 = {};
-  for (var attr in obj1) {
-    if (obj1.hasOwnProperty(attr)) {
-      obj3[attr] = obj1[attr];
-    }
-  }
-  for (var name in obj2) {
-    if (obj2.hasOwnProperty(name)) {
-      obj3[name] = obj2[name];
-    }
-  }
-  return obj3;
-}
-
-/**
- * Yields a warning for a given deprecated property.
- * @function
- * @param {string} propertyName - The property to warn about.
- */
-function deprecatedPropertyWarning(propertyName) {
-  if (propertyName === 'tag') {
-    console.warn('tag will be deprecated in v2.0.0');
-    console.warn('Please use tags as it aligns with the swagger v2.0 spec.');
-  }
-}
-
-/**
- * Adds the tags property to a swagger object.
- * @function
- * @param {object} conf - Flexible configuration.
- */
-function attachTags(conf) {
-  var tag = conf.tag;
-  var swaggerObject = conf.swaggerObject;
-  var propertyName = conf.propertyName;
-
-  // Correct deprecated property.
-  if (propertyName === 'tag') {
-    propertyName = 'tags';
-  }
-
-  if (Array.isArray(tag)) {
-    for (var i = 0; i < tag.length; i = i + 1) {
-      swaggerObject[propertyName].push(tag[i]);
-    }
-  } else {
-    swaggerObject[propertyName].push(tag);
-  }
-}
-
-/**
- * Adds the data in to the swagger object.
- * @function
- * @param {object} swaggerObject - Swagger object which will be written to
- * @param {object[]} data - objects of parsed swagger data from yaml or jsDoc
- *                          comments
- */
-function addDataToSwaggerObject(swaggerObject, data) {
-  for (var i = 0; i < data.length; i = i + 1) {
-    var pathObject = data[i];
-    var propertyNames = Object.getOwnPropertyNames(pathObject);
-    // Iterating the properties of the a given pathObject.
-    for (var j = 0; j < propertyNames.length; j = j + 1) {
-      var propertyName = propertyNames[j];
-      switch (propertyName) {
-        case 'securityDefinition':
-        case 'response':
-        case 'parameter':
-        case 'definition': {
-          var keyName = propertyName + 's';
-          var definitionNames = Object
-            .getOwnPropertyNames(pathObject[propertyName]);
-          for (var k = 0; k < definitionNames.length; k = k + 1) {
-            var definitionName = definitionNames[k];
-            swaggerObject[keyName][definitionName] =
-              pathObject[propertyName][definitionName];
-          }
-          break;
-        }
-        case 'tag':
-        case 'tags': {
-          deprecatedPropertyWarning(propertyName);
-          var tag = pathObject[propertyName];
-          attachTags({
-            tag: tag,
-            swaggerObject: swaggerObject,
-            propertyName: propertyName,
-          });
-          break;
-        }
-        // Assumes a path property if nothing else matches.
-        default: {
-          swaggerObject.paths[propertyName] = objectMerge(
-            swaggerObject.paths[propertyName], pathObject[propertyName]
-          );
-        }
-      }
-    }
-  }
 }
 
 /**
@@ -207,25 +98,15 @@ module.exports = function(options) {
   }
 
   // Build basic swagger json
-  var swaggerObject = [];
-  swaggerObject = options.swaggerDefinition;
-  swaggerObject.swagger = '2.0';
-
-  swaggerObject.paths = swaggerObject.paths || {};
-  swaggerObject.definitions = swaggerObject.definitions || {};
-  swaggerObject.responses = swaggerObject.responses || {};
-  swaggerObject.parameters = swaggerObject.parameters || {};
-  swaggerObject.securityDefinitions = swaggerObject.securityDefinitions || {};
-  swaggerObject.tags = swaggerObject.tags || [];
-
+  var swaggerObject = swaggerHelpers.swaggerizeObj(options.swaggerDefinition);
   var apiPaths = convertGlobPaths(options.apis);
 
   // Parse the documentation in the APIs array.
   for (var i = 0; i < apiPaths.length; i = i + 1) {
     var files = parseApiFile(apiPaths[i]);
     var swaggerJsDocComments = filterJsDocComments(files.jsdoc);
-    addDataToSwaggerObject(swaggerObject, files.yaml);
-    addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, files.yaml);
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
   }
 
   parser.parse(swaggerObject, function(err, api) {
@@ -233,5 +114,6 @@ module.exports = function(options) {
       swaggerObject = api;
     }
   });
+
   return swaggerObject;
 };

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * Yields a warning for a given deprecated property.
+ * @function
+ * @param {string} propertyName - The property to warn about.
+ */
+function _deprecatedPropertyWarning(propertyName) {
+  if (propertyName === 'tag') {
+    console.warn('tag will be deprecated in v2.0.0');
+    console.warn('Please use tags as it aligns with the swagger v2.0 spec.');
+  }
+}
+
+/**
+ * Adds the tags property to a swagger object.
+ * @function
+ * @param {object} conf - Flexible configuration.
+ */
+function _attachTags(conf) {
+  var tag = conf.tag;
+  var swaggerObject = conf.swaggerObject;
+  var propertyName = conf.propertyName;
+
+  // Correct deprecated property.
+  if (propertyName === 'tag') {
+    propertyName = 'tags';
+  }
+
+  if (Array.isArray(tag)) {
+    for (var i = 0; i < tag.length; i = i + 1) {
+      swaggerObject[propertyName].push(tag[i]);
+    }
+  } else {
+    swaggerObject[propertyName].push(tag);
+  }
+}
+
+/**
+ * Merges two objects
+ * @function
+ * @param {object} obj1 - Object 1
+ * @param {object} obj2 - Object 2
+ * @returns {object} Merged Object
+ */
+function _objectMerge(obj1, obj2) {
+  var obj3 = {};
+  for (var attr in obj1) {
+    if (obj1.hasOwnProperty(attr)) {
+      obj3[attr] = obj1[attr];
+    }
+  }
+  for (var name in obj2) {
+    if (obj2.hasOwnProperty(name)) {
+      obj3[name] = obj2[name];
+    }
+  }
+  return obj3;
+}
+
+/**
+ * Adds necessary swagger schema object properties.
+ * @see https://goo.gl/Eoagtl
+ * @function
+ * @param {object} swaggerObject - The object to receive properties.
+ * @returns {object} swaggerObject - The updated object.
+ */
+function swaggerizeObj(swaggerObject) {
+  swaggerObject.swagger = '2.0';
+  swaggerObject.paths = swaggerObject.paths || {};
+  swaggerObject.definitions = swaggerObject.definitions || {};
+  swaggerObject.responses = swaggerObject.responses || {};
+  swaggerObject.parameters = swaggerObject.parameters || {};
+  swaggerObject.securityDefinitions = swaggerObject.securityDefinitions || {};
+  swaggerObject.tags = swaggerObject.tags || [];
+  return swaggerObject;
+}
+
+/**
+ * Adds the data in to the swagger object.
+ * @function
+ * @param {object} swaggerObject - Swagger object which will be written to
+ * @param {object[]} data - objects of parsed swagger data from yaml or jsDoc
+ *                          comments
+ */
+function addDataToSwaggerObject(swaggerObject, data) {
+  for (var i = 0; i < data.length; i = i + 1) {
+    var pathObject = data[i];
+    var propertyNames = Object.getOwnPropertyNames(pathObject);
+    // Iterating the properties of the a given pathObject.
+    for (var j = 0; j < propertyNames.length; j = j + 1) {
+      var propertyName = propertyNames[j];
+      switch (propertyName) {
+        case 'securityDefinition':
+        case 'response':
+        case 'parameter':
+        case 'definition': {
+          var keyName = propertyName + 's';
+          var definitionNames = Object
+            .getOwnPropertyNames(pathObject[propertyName]);
+          for (var k = 0; k < definitionNames.length; k = k + 1) {
+            var definitionName = definitionNames[k];
+            swaggerObject[keyName][definitionName] =
+              pathObject[propertyName][definitionName];
+          }
+          break;
+        }
+        case 'tag':
+        case 'tags': {
+          _deprecatedPropertyWarning(propertyName);
+          var tag = pathObject[propertyName];
+          _attachTags({
+            tag: tag,
+            swaggerObject: swaggerObject,
+            propertyName: propertyName,
+          });
+          break;
+        }
+        // Assumes a path property if nothing else matches.
+        default: {
+          swaggerObject.paths[propertyName] = _objectMerge(
+            swaggerObject.paths[propertyName], pathObject[propertyName]
+          );
+        }
+      }
+    }
+  }
+}
+
+module.exports = {
+  addDataToSwaggerObject: addDataToSwaggerObject,
+  swaggerizeObj: swaggerizeObj,
+};

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -84,6 +84,10 @@ function swaggerizeObj(swaggerObject) {
  *                          comments
  */
 function addDataToSwaggerObject(swaggerObject, data) {
+  if (!swaggerObject || !data) {
+    throw new Error('swaggerObject and data are required!');
+  }
+
   for (var i = 0; i < data.length; i = i + 1) {
     var pathObject = data[i];
     var propertyNames = Object.getOwnPropertyNames(pathObject);

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -106,6 +106,46 @@ function _getSwaggerKey(propertyName) {
   return propertyName;
 }
 
+function _handleSwaggerProperties(swaggerObject, pathObject, propertyName) {
+  switch (propertyName) {
+    case 'securityDefinition':
+    case 'securityDefinitions':
+    case 'response':
+    case 'responses':
+    case 'parameter':
+    case 'parameters':
+    case 'definition':
+    case 'definitions': {
+      var keyName = _getSwaggerKey(propertyName);
+      var definitionNames = Object
+        .getOwnPropertyNames(pathObject[propertyName]);
+      for (var k = 0; k < definitionNames.length; k = k + 1) {
+        var definitionName = definitionNames[k];
+        swaggerObject[keyName][definitionName] =
+          pathObject[propertyName][definitionName];
+      }
+      break;
+    }
+    case 'tag':
+    case 'tags': {
+      _deprecatedPropertyWarning(propertyName);
+      var tag = pathObject[propertyName];
+      _attachTags({
+        tag: tag,
+        swaggerObject: swaggerObject,
+        propertyName: propertyName,
+      });
+      break;
+    }
+    // Assumes a path property if nothing else matches.
+    default: {
+      swaggerObject.paths[propertyName] = _objectMerge(
+        swaggerObject.paths[propertyName], pathObject[propertyName]
+      );
+    }
+  }
+}
+
 /**
  * Adds the data in to the swagger object.
  * @function
@@ -124,43 +164,8 @@ function addDataToSwaggerObject(swaggerObject, data) {
     // Iterating the properties of the a given pathObject.
     for (var j = 0; j < propertyNames.length; j = j + 1) {
       var propertyName = propertyNames[j];
-      switch (propertyName) {
-        case 'securityDefinition':
-        case 'securityDefinitions':
-        case 'response':
-        case 'responses':
-        case 'parameter':
-        case 'parameters':
-        case 'definition':
-        case 'definitions': {
-          var keyName = _getSwaggerKey(propertyName);
-          var definitionNames = Object
-            .getOwnPropertyNames(pathObject[propertyName]);
-          for (var k = 0; k < definitionNames.length; k = k + 1) {
-            var definitionName = definitionNames[k];
-            swaggerObject[keyName][definitionName] =
-              pathObject[propertyName][definitionName];
-          }
-          break;
-        }
-        case 'tag':
-        case 'tags': {
-          _deprecatedPropertyWarning(propertyName);
-          var tag = pathObject[propertyName];
-          _attachTags({
-            tag: tag,
-            swaggerObject: swaggerObject,
-            propertyName: propertyName,
-          });
-          break;
-        }
-        // Assumes a path property if nothing else matches.
-        default: {
-          swaggerObject.paths[propertyName] = _objectMerge(
-            swaggerObject.paths[propertyName], pathObject[propertyName]
-          );
-        }
-      }
+      // Do what's necessary to organize the end specification.
+      _handleSwaggerProperties(swaggerObject, pathObject, propertyName);
     }
   }
 }

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Dependencies.
+var RecursiveIterator = require('recursive-iterator');
+
 /**
  * Adds the tags property to a swagger object.
  * @function
@@ -183,16 +186,10 @@ function addDataToSwaggerObject(swaggerObject, data) {
  * @param {Array} problems - aggregate list of found problems
  */
 function seekWrong(list, wrongSet, problems) {
-  // @TODO: treat list well {Array|object}
-  for (var property in list) {
-    if (list.hasOwnProperty(property)) {
-      // The property is wrong.
-      if (wrongSet.indexOf(property) > 0) {
-        problems.push(problems);
-      }
-      if (typeof list[property] == 'object' ) {
-        seekWrong(object[property], wrongSet, problems);
-      }
+  var iterator = new RecursiveIterator(list, 0, false);
+  for (var item = iterator.next(); !item.done; item = iterator.next()) {
+    if (wrongSet.indexOf(item.value.key) > 0) {
+      problems.push(item.value.key);
     }
   }
 }
@@ -204,8 +201,8 @@ function seekWrong(list, wrongSet, problems) {
  * @returns {Array} problems - a list of problems encountered
  */
 function findDeprecated(sources) {
-  // @TODO: change to by dynamic
-  var wrong = ['tags', 'definitions'];
+  var wrong = _getSwaggerSchemaWrongProperties();
+  // accumulate problems encountered
   var problems = [];
   sources.forEach(function(source) {
     // Iterate through `source`, search for `wrong`, accumulate in `problems`.

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -106,43 +106,49 @@ function _getSwaggerKey(propertyName) {
   return propertyName;
 }
 
-function _handleSwaggerProperties(swaggerObject, pathObject, propertyName) {
-  switch (propertyName) {
-    case 'securityDefinition':
-    case 'securityDefinitions':
-    case 'response':
-    case 'responses':
-    case 'parameter':
-    case 'parameters':
-    case 'definition':
-    case 'definitions': {
-      var keyName = _getSwaggerKey(propertyName);
-      var definitionNames = Object
-        .getOwnPropertyNames(pathObject[propertyName]);
-      for (var k = 0; k < definitionNames.length; k = k + 1) {
-        var definitionName = definitionNames[k];
-        swaggerObject[keyName][definitionName] =
-          pathObject[propertyName][definitionName];
-      }
-      break;
+/**
+ * Handles swagger propertyName in pathObject context for swaggerObject.
+ * @function
+ * @param {object} swaggerObject - The swagger object to update.
+ * @param {object} pathObject - The input context of an item for swaggerObject.
+ * @param {string} propertyName - The property to handle.
+ */
+function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
+  var simpleProperties = [
+    'securityDefinition',
+    'securityDefinitions',
+    'response',
+    'responses',
+    'parameter',
+    'parameters',
+    'definition',
+    'definitions',
+  ];
+
+  // Common properties.
+  if (simpleProperties.indexOf(propertyName) !== -1) {
+    var keyName = _getSwaggerKey(propertyName);
+    var definitionNames = Object
+      .getOwnPropertyNames(pathObject[propertyName]);
+    for (var k = 0; k < definitionNames.length; k = k + 1) {
+      var definitionName = definitionNames[k];
+      swaggerObject[keyName][definitionName] =
+        pathObject[propertyName][definitionName];
     }
-    case 'tag':
-    case 'tags': {
-      _deprecatedPropertyWarning(propertyName);
-      var tag = pathObject[propertyName];
-      _attachTags({
-        tag: tag,
-        swaggerObject: swaggerObject,
-        propertyName: propertyName,
-      });
-      break;
-    }
-    // Assumes a path property if nothing else matches.
-    default: {
-      swaggerObject.paths[propertyName] = _objectMerge(
-        swaggerObject.paths[propertyName], pathObject[propertyName]
-      );
-    }
+  // Tags.
+  } else if (propertyName === 'tag' || propertyName === 'tags') {
+    _deprecatedPropertyWarning(propertyName);
+    var tag = pathObject[propertyName];
+    _attachTags({
+      tag: tag,
+      swaggerObject: swaggerObject,
+      propertyName: propertyName,
+    });
+  // Paths.
+  } else {
+    swaggerObject.paths[propertyName] = _objectMerge(
+      swaggerObject.paths[propertyName], pathObject[propertyName]
+    );
   }
 }
 
@@ -165,7 +171,7 @@ function addDataToSwaggerObject(swaggerObject, data) {
     for (var j = 0; j < propertyNames.length; j = j + 1) {
       var propertyName = propertyNames[j];
       // Do what's necessary to organize the end specification.
-      _handleSwaggerProperties(swaggerObject, pathObject, propertyName);
+      _organizeSwaggerProperties(swaggerObject, pathObject, propertyName);
     }
   }
 }

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -176,19 +176,41 @@ function addDataToSwaggerObject(swaggerObject, data) {
 }
 
 /**
+ * Aggregates a list of wrong properties in problems.
+ * Searches in object based on a list of wrongSet.
+ * @param {Array|object} list - a list to iterate
+ * @param {Array} wrongSet - a list of wrong properties
+ * @param {Array} problems - aggregate list of found problems
+ */
+function seekWrong(list, wrongSet, problems) {
+  // @TODO: treat list well {Array|object}
+  for (var property in list) {
+    if (list.hasOwnProperty(property)) {
+      // The property is wrong.
+      if (wrongSet.indexOf(property) > 0) {
+        problems.push(problems);
+      }
+      if (typeof list[property] == 'object' ) {
+        seekWrong(object[property], wrongSet, problems);
+      }
+    }
+  }
+}
+
+/**
  * Returns a list of problematic tags if any.
- * @param sources
- * @returns {Array}
+ * @function
+ * @param {Array} sources - a list of objects to iterate and check
+ * @returns {Array} problems - a list of problems encountered
  */
 function findDeprecated(sources) {
-  var wrong = _getSwaggerSchemaWrongProperties();
-
+  // @TODO: change to by dynamic
+  var wrong = ['tags', 'definitions'];
   var problems = [];
   sources.forEach(function(source) {
-    // Transverse the source for wrong usages.
-    console.log(source);
+    // Iterate through `source`, search for `wrong`, accumulate in `problems`.
+    seekWrong(source, wrong, problems);
   });
-
   return problems;
 }
 

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -77,6 +77,36 @@ function swaggerizeObj(swaggerObject) {
 }
 
 /**
+ * List of deprecated property names.
+ * @function
+ * @returns {array} The list of deprecated property names.
+ */
+function _getDeprecatePropertyNames() {
+  return [
+    'tag',
+    'definition',
+    'securityDefinition',
+    'response',
+    'parameter',
+  ];
+}
+
+/**
+ * Makes a deprecated property plural if necessary.
+ * @function
+ * @param {string} propertyName - The swagger property name to check.
+ * @returns {string} The updated propertyName if neccessary.
+ */
+function _getSwaggerKey(propertyName) {
+  var deprecated = _getDeprecatePropertyNames();
+  if (deprecated.indexOf(propertyName) > 0) {
+    // Returns the corrected property name.
+    return propertyName + 's';
+  }
+  return propertyName;
+}
+
+/**
  * Adds the data in to the swagger object.
  * @function
  * @param {object} swaggerObject - Swagger object which will be written to
@@ -96,10 +126,14 @@ function addDataToSwaggerObject(swaggerObject, data) {
       var propertyName = propertyNames[j];
       switch (propertyName) {
         case 'securityDefinition':
+        case 'securityDefinitions':
         case 'response':
+        case 'responses':
         case 'parameter':
-        case 'definition': {
-          var keyName = propertyName + 's';
+        case 'parameters':
+        case 'definition':
+        case 'definitions': {
+          var keyName = _getSwaggerKey(propertyName);
           var definitionNames = Object
             .getOwnPropertyNames(pathObject[propertyName]);
           for (var k = 0; k < definitionNames.length; k = k + 1) {

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -1,18 +1,6 @@
 'use strict';
 
 /**
- * Yields a warning for a given deprecated property.
- * @function
- * @param {string} propertyName - The property to warn about.
- */
-function _deprecatedPropertyWarning(propertyName) {
-  if (propertyName === 'tag') {
-    console.warn('tag will be deprecated in v2.0.0');
-    console.warn('Please use tags as it aligns with the swagger v2.0 spec.');
-  }
-}
-
-/**
  * Adds the tags property to a swagger object.
  * @function
  * @param {object} conf - Flexible configuration.
@@ -77,15 +65,19 @@ function swaggerizeObj(swaggerObject) {
 }
 
 /**
- * List of deprecated property names.
+ * List of deprecated or wrong swagger schema properties in singular.
  * @function
  * @returns {array} The list of deprecated property names.
  */
-function _getDeprecatePropertyNames() {
+function _getSwaggerSchemaWrongProperties() {
   return [
+    'consume',
+    'produce',
+    'path',
     'tag',
     'definition',
     'securityDefinition',
+    'scheme',
     'response',
     'parameter',
   ];
@@ -97,9 +89,9 @@ function _getDeprecatePropertyNames() {
  * @param {string} propertyName - The swagger property name to check.
  * @returns {string} The updated propertyName if neccessary.
  */
-function _getSwaggerKey(propertyName) {
-  var deprecated = _getDeprecatePropertyNames();
-  if (deprecated.indexOf(propertyName) > 0) {
+function _correctSwaggerKey(propertyName) {
+  var wrong = _getSwaggerSchemaWrongProperties();
+  if (wrong.indexOf(propertyName) > 0) {
     // Returns the corrected property name.
     return propertyName + 's';
   }
@@ -115,6 +107,14 @@ function _getSwaggerKey(propertyName) {
  */
 function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
   var simpleProperties = [
+    'consume',
+    'consumes',
+    'produce',
+    'produces',
+    'path',
+    'paths',
+    'schema',
+    'schemas',
     'securityDefinition',
     'securityDefinitions',
     'response',
@@ -127,7 +127,7 @@ function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
 
   // Common properties.
   if (simpleProperties.indexOf(propertyName) !== -1) {
-    var keyName = _getSwaggerKey(propertyName);
+    var keyName = _correctSwaggerKey(propertyName);
     var definitionNames = Object
       .getOwnPropertyNames(pathObject[propertyName]);
     for (var k = 0; k < definitionNames.length; k = k + 1) {
@@ -137,7 +137,6 @@ function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
     }
   // Tags.
   } else if (propertyName === 'tag' || propertyName === 'tags') {
-    _deprecatedPropertyWarning(propertyName);
     var tag = pathObject[propertyName];
     _attachTags({
       tag: tag,
@@ -156,7 +155,7 @@ function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
  * Adds the data in to the swagger object.
  * @function
  * @param {object} swaggerObject - Swagger object which will be written to
- * @param {object[]} data - objects of parsed swagger data from yaml or jsDoc
+ * @param {object[]} data - objects of parsed swagger data from yml or jsDoc
  *                          comments
  */
 function addDataToSwaggerObject(swaggerObject, data) {
@@ -176,7 +175,25 @@ function addDataToSwaggerObject(swaggerObject, data) {
   }
 }
 
+/**
+ * Returns a list of problematic tags if any.
+ * @param sources
+ * @returns {Array}
+ */
+function findDeprecated(sources) {
+  var wrong = _getSwaggerSchemaWrongProperties();
+
+  var problems = [];
+  sources.forEach(function(source) {
+    // Transverse the source for wrong usages.
+    console.log(source);
+  });
+
+  return problems;
+}
+
 module.exports = {
   addDataToSwaggerObject: addDataToSwaggerObject,
   swaggerizeObj: swaggerizeObj,
+  findDeprecated: findDeprecated,
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "doctrine": "^1.2.0",
     "glob": "^7.0.3",
     "js-yaml": "^3.5.3",
+    "recursive-iterator": "^2.0.3",
     "swagger-parser": "^3.4.0"
   },
   "devDependencies": {

--- a/test/fixtures/swaggerObject.json
+++ b/test/fixtures/swaggerObject.json
@@ -1,0 +1,28 @@
+{
+  "info":{
+    "title":"Hello World",
+    "version":"1.0.0",
+    "description":"A sample API"
+  },
+  "host":"localhost:3000",
+  "basePath":"/",
+  "swagger":"2.0",
+  "paths":{
+
+  },
+  "definitions":{
+
+  },
+  "responses":{
+
+  },
+  "parameters":{
+
+  },
+  "securityDefinitions":{
+
+  },
+  "tags":[
+
+  ]
+}

--- a/test/fixtures/swaggerObject.json
+++ b/test/fixtures/swaggerObject.json
@@ -7,22 +7,15 @@
   "host":"localhost:3000",
   "basePath":"/",
   "swagger":"2.0",
-  "paths":{
-
-  },
-  "definitions":{
-
-  },
-  "responses":{
-
-  },
-  "parameters":{
-
-  },
-  "securityDefinitions":{
-
-  },
-  "tags":[
-
-  ]
+  "schemes":[],
+  "consumes":[],
+  "produces":[],
+  "paths":{},
+  "definitions":{},
+  "responses":{},
+  "parameters":{},
+  "securityDefinitions":{},
+  "security":{},
+  "tags":[],
+  "externalDocs": {}
 }

--- a/test/fixtures/testData.js
+++ b/test/fixtures/testData.js
@@ -1,0 +1,8 @@
+var testDataDefinitions = [{"/":{"get":{"description":"Returns the homepage","responses":{"200":{"description":"hello world"}}}}},{"definition":{"Login":{"required":["username","password"],"properties":{"username":{"type":"string"},"password":{"type":"string"}}}}},{"tags":{"name":"Users","description":"User management and login"}},{"tags":[{"name":"Login","description":"Login"},{"name":"Accounts","description":"Accounts"}]},{"/login":{"post":{"description":"Login to the application","tags":["Users","Login"],"produces":["application/json"],"parameters":[{"$ref":"#/parameters/username"},{"name":"password","description":"User's password.","in":"formData","required":true,"type":"string"}],"responses":{"200":{"description":"login","schema":{"type":"object","$ref":"#/definitions/Login"}}}}}},{"/users":{"get":{"description":"Returns users","tags":["Users"],"produces":["application/json"],"responses":{"200":{"description":"users"}}}}},{"/users":{"post":{"description":"Returns users","tags":["Users"],"produces":["application/json"],"parameters":[{"$ref":"#/parameters/username"}],"responses":{"200":{"description":"users"}}}}}];
+var testDataTags = [{"/hello":{"get":{"description":"Returns the homepage","responses":{"200":{"description":"hello world"}}}}}];
+var data3 = [{"parameter":{"username":{"name":"username","description":"Username to use for login.","in":"formData","required":true,"type":"string"}}}];
+
+module.exports = {
+  definitions: testDataDefinitions,
+  tags: testDataTags,
+};

--- a/test/fixtures/testData.js
+++ b/test/fixtures/testData.js
@@ -1,8 +1,36 @@
-var testDataDefinitions = [{"/":{"get":{"description":"Returns the homepage","responses":{"200":{"description":"hello world"}}}}},{"definition":{"Login":{"required":["username","password"],"properties":{"username":{"type":"string"},"password":{"type":"string"}}}}},{"tags":{"name":"Users","description":"User management and login"}},{"tags":[{"name":"Login","description":"Login"},{"name":"Accounts","description":"Accounts"}]},{"/login":{"post":{"description":"Login to the application","tags":["Users","Login"],"produces":["application/json"],"parameters":[{"$ref":"#/parameters/username"},{"name":"password","description":"User's password.","in":"formData","required":true,"type":"string"}],"responses":{"200":{"description":"login","schema":{"type":"object","$ref":"#/definitions/Login"}}}}}},{"/users":{"get":{"description":"Returns users","tags":["Users"],"produces":["application/json"],"responses":{"200":{"description":"users"}}}}},{"/users":{"post":{"description":"Returns users","tags":["Users"],"produces":["application/json"],"parameters":[{"$ref":"#/parameters/username"}],"responses":{"200":{"description":"users"}}}}}];
-var testDataTags = [{"/hello":{"get":{"description":"Returns the homepage","responses":{"200":{"description":"hello world"}}}}}];
-var data3 = [{"parameter":{"username":{"name":"username","description":"Username to use for login.","in":"formData","required":true,"type":"string"}}}];
+var testDataDefinitions = [
+  {
+    "definition": {
+      "Login": {
+        "required": ["username", "password"],
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  {
+    "definitions": {
+      "Login2": {
+        "required": ["username", "password"],
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+];
 
 module.exports = {
-  definitions: testDataDefinitions,
-  tags: testDataTags,
+  definitions: testDataDefinitions
 };

--- a/test/fixtures/testData.js
+++ b/test/fixtures/testData.js
@@ -1,7 +1,7 @@
 var testDataDefinitions = [
   {
     "definition": {
-      "Login": {
+      "DefinitionSingular": {
         "required": ["username", "password"],
         "properties": {
           "username": {
@@ -16,7 +16,7 @@ var testDataDefinitions = [
   },
   {
     "definitions": {
-      "Login2": {
+      "DefinitionPlural": {
         "required": ["username", "password"],
         "properties": {
           "username": {
@@ -31,6 +31,33 @@ var testDataDefinitions = [
   }
 ];
 
+var testDataParameters = [
+  {
+    "parameter": {
+      "ParameterSingular": {
+        "name": "username",
+        "description": "Username to use for login.",
+        "in": "formData",
+        "required": true,
+        "type": "string"
+      }
+    }
+  },
+  {
+    "parameters": {
+      "ParameterPlural": {
+        "name": "limit",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  }
+  ];
+
 module.exports = {
-  definitions: testDataDefinitions
+  definitions: testDataDefinitions,
+  parameters: testDataParameters,
 };

--- a/test/fixtures/testData.js
+++ b/test/fixtures/testData.js
@@ -1,3 +1,4 @@
+// Mock for Definitions Object. `definitions` is correct, not `definition`.
 var testDataDefinitions = [
   {
     "definition": {
@@ -31,6 +32,7 @@ var testDataDefinitions = [
   }
 ];
 
+// Mock for Parameters Definitions Object. `parameters` is correct, not `parameter`.
 var testDataParameters = [
   {
     "parameter": {
@@ -55,9 +57,59 @@ var testDataParameters = [
       }
     }
   }
-  ];
+];
+
+// Mock for Security Definitions Object. `securityDefinitions` is correct, not `securityDefinition`.
+var testDataSecurityDefinitions = [
+  {
+    "securityDefinition": {
+      "basicAuth": {
+        "type": "basic",
+        "description": "HTTP Basic Authentication. Works over `HTTP` and `HTTPS`"
+      }
+    }
+  },
+  {
+    "securityDefinitions": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "authorizationUrl": "http://swagger.io/api/oauth/dialog",
+        "flow": "implicit",
+        "scopes": {
+          "write:pets": "modify pets in your account",
+          "read:pets": "read your pets"
+        }
+      },
+    }
+  }
+];
+
+// Mock for Responses Definitions Object. `responses` is correct, not `response`.
+var testDataResponses = [
+  {
+    "response": {
+      "NotFound": {
+        "description": "Entity not found."
+      }
+    }
+  },
+  {
+    "responses": {
+      "IllegalInput": {
+        "description": "Illegal input for operation."
+      }
+    }
+  }
+];
 
 module.exports = {
   definitions: testDataDefinitions,
   parameters: testDataParameters,
+  securityDefinitions: testDataSecurityDefinitions,
+  responses: testDataResponses,
 };

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -32,7 +32,7 @@ describe('swagger-helpers submodule', function () {
     expect(swaggerObject.definitions).to.include.keys('DefinitionPlural');
     done();
   });
-  
+
   it('addDataToSwaggerObject() handles "parameter" and "parameters"', function(done) {
     swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.parameters);
     expect(swaggerObject.parameters).to.exist;
@@ -41,7 +41,27 @@ describe('swagger-helpers submodule', function () {
     // Case 'parameters'.
     expect(swaggerObject.parameters).to.include.keys('ParameterPlural');
     done();
-  });  
+  });
+
+  it('addDataToSwaggerObject() handles "securityDefinition" and "securityDefinitions"', function(done) {
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.securityDefinitions);
+    expect(swaggerObject.securityDefinitions).to.exist;
+    // Case 'securityDefinition'.
+    expect(swaggerObject.securityDefinitions).to.include.keys('basicAuth');
+    // Case 'securityDefinitions'.
+    expect(swaggerObject.securityDefinitions).to.include.keys('api_key');
+    done();
+  });
+
+  it('addDataToSwaggerObject() handles "response" and "responses"', function(done) {
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.responses);
+    expect(swaggerObject.responses).to.exist;
+    // Case 'response'.
+    expect(swaggerObject.responses).to.include.keys('NotFound');
+    // Case 'responses'.
+    expect(swaggerObject.responses).to.include.keys('IllegalInput');
+    done();
+  });
 
   it('should have a method swaggerizeObj()', function (done) {
     expect(swaggerHelpers).to.include.keys('swaggerizeObj');

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// The hinter will deny a lot of the chai syntax (W030).
+/* jshint ignore:start */
+
+// Dependencies.
+var swaggerHelpers = require('../lib/swagger-helpers');
+var chai = require('chai');
+var expect = chai.expect;
+
+describe('swagger-helpers submodule', function () {
+
+  it('should have a method addDataToSwaggerObject()', function (done) {
+    expect(swaggerHelpers).to.include.keys('addDataToSwaggerObject');
+    expect(swaggerHelpers.addDataToSwaggerObject).to.be.function;
+    done();
+  });
+
+  it('addDataToSwaggerObject() should require correct input', function (done) {
+    expect(swaggerHelpers.addDataToSwaggerObject).to.throw(Error);
+    done();
+  });
+
+  it('should have a method swaggerizeObj()', function (done) {
+    expect(swaggerHelpers).to.include.keys('swaggerizeObj');
+    expect(swaggerHelpers.swaggerizeObj).to.be.function;
+    done();
+  });
+
+});
+/* jshint ignore:end */

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -7,6 +7,8 @@
 var swaggerHelpers = require('../lib/swagger-helpers');
 var chai = require('chai');
 var expect = chai.expect;
+var swaggerObject = require('./fixtures/swaggerObject.json');
+var testData = require('./fixtures/testData');
 
 describe('swagger-helpers submodule', function () {
 
@@ -18,6 +20,11 @@ describe('swagger-helpers submodule', function () {
 
   it('addDataToSwaggerObject() should require correct input', function (done) {
     expect(swaggerHelpers.addDataToSwaggerObject).to.throw(Error);
+    done();
+  });
+
+  it('addDataToSwaggerObject() handles tags "tags" field', function(done) {
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.tags);
     done();
   });
 

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -23,8 +23,13 @@ describe('swagger-helpers submodule', function () {
     done();
   });
 
-  it('addDataToSwaggerObject() handles tags "tags" field', function(done) {
-    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.tags);
+  it('addDataToSwaggerObject() handles "definition" and "definitions"', function(done) {
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.definitions);
+    expect(swaggerObject.definitions).to.exist;
+    // Case 'definition'.
+    expect(swaggerObject.definitions).to.include.keys('Login');
+    // Case 'definitions'.
+    expect(swaggerObject.definitions).to.include.keys('Login2');
     done();
   });
 

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -27,11 +27,21 @@ describe('swagger-helpers submodule', function () {
     swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.definitions);
     expect(swaggerObject.definitions).to.exist;
     // Case 'definition'.
-    expect(swaggerObject.definitions).to.include.keys('Login');
+    expect(swaggerObject.definitions).to.include.keys('DefinitionSingular');
     // Case 'definitions'.
-    expect(swaggerObject.definitions).to.include.keys('Login2');
+    expect(swaggerObject.definitions).to.include.keys('DefinitionPlural');
     done();
   });
+  
+  it('addDataToSwaggerObject() handles "parameter" and "parameters"', function(done) {
+    swaggerHelpers.addDataToSwaggerObject(swaggerObject, testData.parameters);
+    expect(swaggerObject.parameters).to.exist;
+    // Case 'parameter'.
+    expect(swaggerObject.parameters).to.include.keys('ParameterSingular');
+    // Case 'parameters'.
+    expect(swaggerObject.parameters).to.include.keys('ParameterPlural');
+    done();
+  });  
 
   it('should have a method swaggerizeObj()', function (done) {
     expect(swaggerHelpers).to.include.keys('swaggerizeObj');


### PR DESCRIPTION
Relates to #38
Updates example files with plural version of properties, while handling both singular and plural.
Currently refactoring definition/definitions and parameter/parameters to solve an open issue.
Yet, the function to parse properties is now placed into a separate module to be testable.
Also, properties "categorization" of deprecated vs correct is done in order to easily continue the refactoring, i.e. there are further properties to be handled: [properties](https://github.com/OAI/OpenAPI-Specification/blob/master//versions/2.0.md#fixed-fields)