### PR TITLE
Updating sample to comply with Swagger v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ model and add fields.
 ```javascript
 /**
  * @swagger
- * definition:
+ * definitions:
  *   NewUser:
  *     type: object
  *     required:


### PR DESCRIPTION
I had to spend quite some time to figure out what was wrong with my code. Apparently, the sample had a deprecated property `definition`, now should be`definitions`