### PR TITLE
Ignore deprecation check

### DIFF
--- a/example/routes.js
+++ b/example/routes.js
@@ -29,6 +29,8 @@ module.exports.setup = function(app) {
    *         type: string
    *       password:
    *         type: string
+   *       path:
+   *         type: string
    */
 
   /**

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -188,7 +188,9 @@ function addDataToSwaggerObject(swaggerObject, data) {
 function seekWrong(list, wrongSet, problems) {
   var iterator = new RecursiveIterator(list, 0, false);
   for (var item = iterator.next(); !item.done; item = iterator.next()) {
-    var isDirectChildOfProperties = item.value.path[item.value.path.length - 2] === 'properties';
+    var isDirectChildOfProperties =
+      item.value.path[item.value.path.length - 2] === 'properties';
+
     if (wrongSet.indexOf(item.value.key) > 0 && !isDirectChildOfProperties) {
       problems.push(item.value.key);
     }

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -188,7 +188,8 @@ function addDataToSwaggerObject(swaggerObject, data) {
 function seekWrong(list, wrongSet, problems) {
   var iterator = new RecursiveIterator(list, 0, false);
   for (var item = iterator.next(); !item.done; item = iterator.next()) {
-    if (wrongSet.indexOf(item.value.key) > 0) {
+    var isDirectChildOfProperties = item.value.path[item.value.path.length - 2] === 'properties';
+    if (wrongSet.indexOf(item.value.key) > 0 && !isDirectChildOfProperties) {
       problems.push(item.value.key);
     }
   }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -62,7 +62,18 @@ describe('command line interface', function () {
       done();
     });
   });
-  
+
+  it('should warn when deprecated properties are used', function (done) {
+    var deprecatedProperties = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js test/fixtures/deprecated_routes.js';
+    exec(deprecatedProperties, function (error, stdout, stderr) {
+      if (error) {
+        throw new Error(error, stderr);
+      }
+      expect(stderr).to.contain('You are using properties to be deprecated');
+      done();
+    });
+  });
+
   it('should require arguments with jsDoc data about an API', function (done) {
     var missingApis = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js';
     exec(missingApis, function (error, stdout, stderr) {
@@ -73,7 +84,7 @@ describe('command line interface', function () {
       done();
     });
   });
-  
+
   it('should create swaggerSpec.json by default when the API input is good', function (done) {
     var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js example/routes.js';
     exec(goodInput, function (error, stdout, stderr) {
@@ -81,13 +92,14 @@ describe('command line interface', function () {
         throw new Error(error, stderr);
       }
       expect(stdout).to.contain('Swagger specification created successfully.');
+      expect(stderr).to.not.contain('You are using properties to be deprecated');
       var specification = fs.statSync('swaggerSpec.json');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
       done();
     });
   });
-  
+
   it('should accept custom configuration for output specification', function (done) {
     var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js -o customSpec.json example/routes.js';
     exec(goodInput, function (error, stdout, stderr) {
@@ -100,8 +112,8 @@ describe('command line interface', function () {
       expect(specification.nlink).to.be.above(0);
       done();
     });
-  });  
-  
+  });
+
   // Cleanup test files if any.
   after(function() {
     var defaultSpecification = process.env.PWD + '/swaggerSpec.json';

--- a/test/fixtures/deprecated_routes.js
+++ b/test/fixtures/deprecated_routes.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports.setup = function(app) {
+  /**
+   * @swagger
+   * /deprecated:
+   *   get:
+   *     description: Returns a string
+   *     path: '/deprecated'
+   *     responses:
+   *       200:
+   *         description: deprecated path
+   */
+  app.get('/deprecated', function(req, res) {
+    res.send('Deprecated "path" property!');
+  });
+};

--- a/test/swagger-spec.json
+++ b/test/swagger-spec.json
@@ -104,6 +104,9 @@
         },
         "password": {
           "type": "string"
+        },
+        "path": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
References issue #44

Ignores deprecation checks if property is a direct child of a 'properties' object.