### PR TITLE
Include watch task in cli tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ app.post('/login', function(req, res) {
 
 A model may be the same for multiple endpoints (Ex. User POST,PUT responses).
 In place of writing (or copy and pasting) the same code into multiple locations,
-which can be error prone when adding a new field to the schema. You can define 
+which can be error prone when adding a new field to the schema. You can define
 a model and re-use it across multiple endpoints. You can also reference another
 model and add fields.
 ```javascript
@@ -130,7 +130,7 @@ model and add fields.
    *         description: users
    *         schema:
    *           type: array
-   *           items: 
+   *           items:
    *             $ref: '#/definitions/User'
    */
   app.get('/users', function(req, res) {
@@ -171,7 +171,7 @@ model and add fields.
   });
 ```
 
-### Load external definitions 
+### Load external definitions
 
 You can load external definitions or paths after ``swaggerJSDoc()`` function.
 ```javascript
@@ -213,3 +213,4 @@ Common usage:
 - Specify a swagger definition file: `./bin/swagger-jsdoc -d example/swaggerDef.js` - could be any .js or .json file which will be `require()`-ed and parsed/validated as JSON.
 - Specify files with documentation: `./bin/swagger-jsdoc example/routes.js example/routes2.js` - free form input, can be before or after definition
 - Specify output file (optional): `./bin/swagger-jsdoc -o output.json` - swaggerSpec.json will be created if this is not set.
+- Watch for changes: `./bin/swagger-jsdoc -d example/swaggerDef.js example/routes.js example/routes2.js -w` - this will add the definition file swaggerDef.js and its arguments routes.js and routes2.js in a watch process, re-generating swagger spec on changes.

--- a/README.md
+++ b/README.md
@@ -213,4 +213,7 @@ Common usage:
 - Specify a swagger definition file: `./bin/swagger-jsdoc -d example/swaggerDef.js` - could be any .js or .json file which will be `require()`-ed and parsed/validated as JSON.
 - Specify files with documentation: `./bin/swagger-jsdoc example/routes.js example/routes2.js` - free form input, can be before or after definition
 - Specify output file (optional): `./bin/swagger-jsdoc -o output.json` - swaggerSpec.json will be created if this is not set.
-- Watch for changes: `./bin/swagger-jsdoc -d example/swaggerDef.js example/routes.js example/routes2.js -w` - this will add the definition file swaggerDef.js and its arguments routes.js and routes2.js in a watch process, re-generating swagger spec on changes.
+- Watch for changes: `./bin/swagger-jsdoc -d example/swaggerDef.js example/routes.js example/routes2.js -w` - start a watch task for input files with API documentation.
+This may be particularly useful when the output specification file is integrated with [Browsersync](https://browsersync.io/)
+and [Swagger UI](http://swagger.io/swagger-ui/). Thus, the developer updates documentation in code with fast feedback in an
+interface showing an example of live documentation based on the swagger specification.

--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -5,7 +5,6 @@
 /**
  * Module dependencies.
  */
-
 var program = require('commander');
 var fs = require('fs');
 var path = require('path');

--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -40,8 +40,7 @@ function createSpecification(swaggerDefinition, apis, output) {
 
   if (ext === '.yml' || ext === '.yaml') {
     swaggerSpec = jsYaml.dump(swaggerJSDoc(options));
-  }
-  else {
+  } else {
     swaggerSpec = JSON.stringify(swaggerJSDoc(options), null, 2);
   }
 

--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -18,12 +18,6 @@ var input = process.argv.slice(2);
 // The spec, following a convention.
 var output = 'swagger.json';
 
-// No-cache module loading.
-function requireNoCache(module) {
-  delete require.cache[require.resolve(module)];
-  return require(module);
-}
-
 /**
  * Creates a swagger specification from a definition and a set of files.
  * @function
@@ -93,7 +87,7 @@ fs.readFile(program.definition, 'utf-8', function(err, data) {
   }
 
   // Get an object of the definition file configuration.
-  var swaggerDefinition = requireNoCache(path.resolve(program.definition));
+  var swaggerDefinition = require(path.resolve(program.definition));
 
   // Check for info object in the definition.
   if (!swaggerDefinition.hasOwnProperty('info')) {
@@ -116,7 +110,7 @@ fs.readFile(program.definition, 'utf-8', function(err, data) {
 
   // If watch flag is turned on, listen for changes.
   if (program.watch) {
-    var watcher = chokidar.watch([program.definition, program.args], {
+    var watcher = chokidar.watch(program.args, {
       awaitWriteFinish: {
         stabilityThreshold: 2000,
         pollInterval: 100,

--- a/example/app.js
+++ b/example/app.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/* istanbul ignore next */
+// This file is an example, it's not functionally used by the module.
+
 // Dependencies
 var express = require('express');
 var bodyParser = require('body-parser');

--- a/example/routes.js
+++ b/example/routes.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* istanbul ignore next */
+// This file is an example, it's not functionally used by the module.
 
 // Sets up the routes.
 module.exports.setup = function(app) {

--- a/example/routes2.js
+++ b/example/routes2.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* istanbul ignore next */
+// This file is an example, it's not functionally used by the module.
 
 module.exports.setup = function(app) {
   /**

--- a/example/swaggerDef.js
+++ b/example/swaggerDef.js
@@ -1,3 +1,6 @@
+/* istanbul ignore next */
+// This file is an example, it's not functionally used by the module.This
+
 var host = 'http://' + process.env.IP + ':' + process.env.PORT;
 
 module.exports = {

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -4,6 +4,32 @@
 var RecursiveIterator = require('recursive-iterator');
 
 /**
+ * Checks if tag is already contained withing target.
+ * The tag is an object of type http://swagger.io/specification/#tagObject
+ * The target, is the part of the swagger specification that holds all tags.
+ * @function
+ * @param {object} target - Swagger object place to include the tags data.
+ * @param {object} tag - Swagger tag object to be included.
+ * @returns {boolean} Does tag is already present in target
+ */
+function _tagDuplicated(target, tag) {
+  // Check input is workable.
+  if (target && target.length && tag) {
+    for (var i = 0; i < target.length; i = i + 1) {
+      var targetTag = target[i];
+      // The name of the tag to include already exists in the taget.
+      // Therefore, it's not necessary to be added again.
+      if (targetTag.name === tag.name) {
+        return true;
+      }
+    }
+  }
+
+  // This will indicate that `tag` is not present in `target`.
+  return false;
+}
+
+/**
  * Adds the tags property to a swagger object.
  * @function
  * @param {object} conf - Flexible configuration.
@@ -20,10 +46,14 @@ function _attachTags(conf) {
 
   if (Array.isArray(tag)) {
     for (var i = 0; i < tag.length; i = i + 1) {
-      swaggerObject[propertyName].push(tag[i]);
+      if (!_tagDuplicated(swaggerObject[propertyName], tag[i])) {
+        swaggerObject[propertyName].push(tag[i]);
+      }
     }
   } else {
-    swaggerObject[propertyName].push(tag);
+    if (!_tagDuplicated(swaggerObject[propertyName], tag)) {
+      swaggerObject[propertyName].push(tag);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "body-parser": "^1.15.0",
     "chai": "^3.5.0",
+    "chokidar": "^1.6.1",
     "express": "^4.13.4",
     "istanbul": "^0.4.2",
     "jscs": "^3.0.0",

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -120,7 +120,7 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('Swagger specification created successfully.');
+      expect(stdout).to.contain('Swagger specification is ready.');
       var specification = fs.statSync('customSpec.yaml');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
@@ -134,7 +134,7 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('Swagger specification created successfully.');
+      expect(stdout).to.contain('Swagger specification is ready.');
       var specification = fs.statSync('customSpec.yml');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
@@ -146,8 +146,12 @@ describe('command line interface', function () {
   after(function() {
     var defaultSpecification = process.env.PWD + '/swagger.json';
     var customSpecification = process.env.PWD + '/customSpec.json';
+    var customSpecYaml = process.env.PWD + '/customSpec.yaml';
+    var customSpecYml = process.env.PWD + '/customSpec.yml';
     fs.unlinkSync(defaultSpecification);
     fs.unlinkSync(customSpecification);
+    fs.unlinkSync(customSpecYaml);
+    fs.unlinkSync(customSpecYml);
   });
 
 });

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -85,15 +85,15 @@ describe('command line interface', function () {
     });
   });
 
-  it('should create swaggerSpec.json by default when the API input is good', function (done) {
+  it('should create swagger.json by default when the API input is good', function (done) {
     var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js example/routes.js';
     exec(goodInput, function (error, stdout, stderr) {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('Swagger specification created successfully.');
+      expect(stdout).to.contain('swagger.json updated.');
       expect(stderr).to.not.contain('You are using properties to be deprecated');
-      var specification = fs.statSync('swaggerSpec.json');
+      var specification = fs.statSync('swagger.json');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
       done();
@@ -106,7 +106,7 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('Swagger specification created successfully.');
+      expect(stdout).to.contain('swagger.json updated.');
       var specification = fs.statSync('customSpec.json');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
@@ -116,7 +116,7 @@ describe('command line interface', function () {
 
   // Cleanup test files if any.
   after(function() {
-    var defaultSpecification = process.env.PWD + '/swaggerSpec.json';
+    var defaultSpecification = process.env.PWD + '/swagger.json';
     var customSpecification = process.env.PWD + '/customSpec.json';
     fs.unlinkSync(defaultSpecification);
     fs.unlinkSync(customSpecification);

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -91,7 +91,7 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('swagger.json updated.');
+      expect(stdout).to.contain('Swagger specification is ready.');
       expect(stderr).to.not.contain('You are using properties to be deprecated');
       var specification = fs.statSync('swagger.json');
       // Check that the physical file was created.
@@ -106,7 +106,7 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('swagger.json updated.');
+      expect(stdout).to.contain('Swagger specification is ready.');
       var specification = fs.statSync('customSpec.json');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);


### PR DESCRIPTION
This suggestion improves the use of the CLI tool, providing a watch task on input files containing API documentation, updating the end specification on change.

The main aim being to simplify integration with browsersync and swagger-ui making workflow (documentation -> testing -> development) process easier.

Notes:
- Default output specification file is renamed to be swagger.json as of [specification convention](http://swagger.io/specification/#file-structure-11).
- Input definition file is not under watch task, because `require` cache. I tried to work around the cache in order to make it possible, but I couldn't. In the end, I think it's more important to keep this part simpler (`.json` or `js` file being possible inputs) and having in mind that this file is usually static and small.
- The function to add tags is extended to avoid duplicate entries
- Turned off test coverage checks for example files which are not functionally used for the module (those in example/ folder) They are lowering the average coverage report but are not really used.