### PR TITLE
Add CLI support for YAML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,4 @@ Common usage:
 - Specify a swagger definition file: `./bin/swagger-jsdoc -d example/swaggerDef.js` - could be any .js or .json file which will be `require()`-ed and parsed/validated as JSON.
 - Specify files with documentation: `./bin/swagger-jsdoc example/routes.js example/routes2.js` - free form input, can be before or after definition
 - Specify output file (optional): `./bin/swagger-jsdoc -o output.json` - swaggerSpec.json will be created if this is not set.
+- If specifying an output file with a .yaml extension, the swagger spec will automatically be saved in YAML format instead of JSON.

--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -10,6 +10,7 @@ var fs = require('fs');
 var path = require('path');
 var swaggerJSDoc = require('../');
 var pkg = require('../package.json');
+var jsYaml = require('js-yaml');
 
 // Useful input.
 var input = process.argv.slice(2);
@@ -96,11 +97,17 @@ fs.readFile(program.definition, 'utf-8', function(err, data) {
     apis: apis,
   };
 
-  // Initialize swagger-jsdoc -> returns validated swagger spec in json format
-  var swaggerSpec = swaggerJSDoc(options);
+  // Initialize swagger-jsdoc -> returns validated JSON or YAML swagger spec
+  var swaggerSpec;
 
   // Create the output file with swagger specification.
-  fs.writeFile(output, JSON.stringify(swaggerSpec, null, 2), function(err) {
+  var ext = path.extname(output);
+  if (ext === '.yml' || ext === '.yaml') {
+    swaggerSpec = jsYaml.dump(swaggerJSDoc(options));
+  } else {
+    swaggerSpec = JSON.stringify(swaggerJSDoc(options), null, 2);
+  }
+  fs.writeFile(output, swaggerSpec, function(err) {
     if (err) {
       throw err;
     }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -114,6 +114,34 @@ describe('command line interface', function () {
     });
   });
 
+  it('should create a YAML swagger spec when a custom output configuration with a .yaml extension is used', function (done) {
+    var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js -o customSpec.yaml example/routes.js';
+    exec(goodInput, function (error, stdout, stderr) {
+      if (error) {
+        throw new Error(error, stderr);
+      }
+      expect(stdout).to.contain('Swagger specification created successfully.');
+      var specification = fs.statSync('customSpec.yaml');
+      // Check that the physical file was created.
+      expect(specification.nlink).to.be.above(0);
+      done();
+    });
+  });
+
+  it('should create a YAML swagger spec when a custom output configuration with a .yml extension is used', function (done) {
+    var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js -o customSpec.yml example/routes.js';
+    exec(goodInput, function (error, stdout, stderr) {
+      if (error) {
+        throw new Error(error, stderr);
+      }
+      expect(stdout).to.contain('Swagger specification created successfully.');
+      var specification = fs.statSync('customSpec.yml');
+      // Check that the physical file was created.
+      expect(specification.nlink).to.be.above(0);
+      done();
+    });
+  });
+
   // Cleanup test files if any.
   after(function() {
     var defaultSpecification = process.env.PWD + '/swaggerSpec.json';


### PR DESCRIPTION
Basically adds support for `./bin/swagger-jsdoc -o output.yaml`.