### PR TITLE
Ignore c9 hidden folder on npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ external.jsdoc
 example/
 jsdoc/
 test/
+.c9/


### PR DESCRIPTION
New entry in the npm ignore file to exclude hidden cloud9 folder on `npm publish` command.