### PR TITLE
chore(release): 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="1.9.3"></a>
+## [1.9.3](https://github.com/Surnet/swagger-jsdoc/compare/v1.9.2...v1.9.3) (2017-04-29)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-jsdoc",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Generates swagger doc based on JSDoc",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Used [conventional-changelog](https://github.com/conventional-changelog/standard-version) to build a changelog and release for 1.9.3, though I can't push to master directly as it's locked.