### PR TITLE
Adding support for APIs in definition file.

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -111,8 +111,18 @@ fs.readFile(program.definition, 'utf-8', function(err, data) {
   }
 
   // Continue only if arguments provided.
-  if (!program.args.length) {
-    return console.log('You must provide arguments for reading APIs.');
+  if (!swaggerDefinition.apis && !program.args.length) {
+    console.log('You must provide sources for reading API files.');
+    // jscs:disable maximumLineLength
+    return console.log('Either add filenames as arguments, or add an api key in your definitions file.');
+  }
+
+  // If there's no argument passed, but the user has defined Apis in
+  // the definition file, pass them them onwards.
+  if (program.args.length === 0 &&
+    swaggerDefinition.apis &&
+    swaggerDefinition.apis instanceof Array) {
+    program.args = swaggerDefinition.apis;
   }
 
   // If watch flag is turned on, listen for changes.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,13 +13,15 @@ $ swagger-jsdoc -h
 
 #### Specify a definition file
 
+Swagger-jsdoc will read the `api` array in your definition file by default for file paths it should read.
+
 ```
-$ swagger-jsdoc -d swaggerDef.js
+$ swagger-jsdoc -d swaggerDef.js -o doc.json
 ```
 
 This could be any .js or .json file which will be `require()`-ed and parsed/validated as JSON.
 
-#### Specify input files
+#### Specify input files (optional)
 
 ```
 $ swagger-jsdoc route1.js route2.js

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -80,13 +80,28 @@ describe('command line interface', function () {
       if (error) {
         throw new Error(error, stderr);
       }
-      expect(stdout).to.contain('You must provide arguments for reading APIs.');
+      expect(stdout).to.contain('You must provide sources for reading API files.');
       done();
     });
   });
 
   it('should create swagger.json by default when the API input is good', function (done) {
     var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d example/swaggerDef.js example/routes.js';
+    exec(goodInput, function (error, stdout, stderr) {
+      if (error) {
+        throw new Error(error, stderr);
+      }
+      expect(stdout).to.contain('Swagger specification is ready.');
+      expect(stderr).to.not.contain('You are using properties to be deprecated');
+      var specification = fs.statSync('swagger.json');
+      // Check that the physical file was created.
+      expect(specification.nlink).to.be.above(0);
+      done();
+    });
+  });
+
+  it('should create swagger.json by default when the API input is from definition file', function (done) {
+    var goodInput = process.env.PWD + '/bin/swagger-jsdoc.js -d test/fixtures/api_definition.js';
     exec(goodInput, function (error, stdout, stderr) {
       if (error) {
         throw new Error(error, stderr);

--- a/test/fixtures/api_definition.js
+++ b/test/fixtures/api_definition.js
@@ -1,0 +1,8 @@
+module.exports = {
+  info: { // API informations (required)
+    title: 'Hello World', // Title (required)
+    version: '1.0.0', // Version (required)
+    description: 'A sample API', // Description (optional)
+  },
+  apis: ['./**/*/routes.js']
+};


### PR DESCRIPTION
This should add the ability to use the `api` key definition in the definitions file to read file sources for APIs.