### PR TITLE
Remove invalid swagger keys from swagger output object

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,12 @@ The swagger spec will be served at http://localhost:3000/api-docs.json
 ### CLI
 
 You can also use the tool via [command line interface](./docs/CLI.md). It supports selecting multiple files, recursive subdirectories and watch task for continuous listening of changes in your code.
+
+### Contributing
+
+- Fork this project and clone locally
+- Branch for each separate feature
+- Write detailed commit messages, comment unclear code blocks and update unit tests
+- Push to your own repository and create a new PR to merge back into this repository
+
+Note: If there are additions to the swagger definition object ensure that the output object keys comply with the swagger specification.  If there are keys that do not comply add them to the `excludedSwaggerProperties` list in `lib/swagger-helpers.js`.

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -2,6 +2,9 @@
 
 // Dependencies.
 var RecursiveIterator = require('recursive-iterator');
+var excludedSwaggerProperties = [
+  'apis',
+];
 
 /**
  * Checks if tag is already contained withing target.
@@ -87,6 +90,13 @@ function _objectMerge(obj1, obj2) {
  * @returns {object} swaggerObject - The updated object.
  */
 function swaggerizeObj(swaggerObject) {
+  // Remove excluded keys from swagger output object
+  excludedSwaggerProperties.forEach(function(key) {
+    if (swaggerObject.hasOwnProperty(key)) {
+      delete swaggerObject[key];
+    }
+  });
+
   swaggerObject.swagger = '2.0';
   swaggerObject.paths = swaggerObject.paths || {};
   swaggerObject.definitions = swaggerObject.definitions || {};

--- a/test/swagger-helpers-test.js
+++ b/test/swagger-helpers-test.js
@@ -14,7 +14,7 @@ describe('swagger-helpers submodule', function () {
 
   it('should have a method addDataToSwaggerObject()', function (done) {
     expect(swaggerHelpers).to.include.keys('addDataToSwaggerObject');
-    expect(swaggerHelpers.addDataToSwaggerObject).to.be.function;
+    expect(typeof(swaggerHelpers.addDataToSwaggerObject)).to.equal('function');
     done();
   });
 
@@ -65,8 +65,17 @@ describe('swagger-helpers submodule', function () {
 
   it('should have a method swaggerizeObj()', function (done) {
     expect(swaggerHelpers).to.include.keys('swaggerizeObj');
-    expect(swaggerHelpers.swaggerizeObj).to.be.function;
+    expect(typeof(swaggerHelpers.swaggerizeObj)).to.equal('function');
     done();
+  });
+  it('swagerizeObj should remove keys specified from the blacklisted keys', function (done) {
+      var testObject = {
+          valid: 'Valid Key',
+          apis: 'Invalid Key'
+      }
+      testObject = swaggerHelpers.swaggerizeObj(testObject);
+      expect(testObject.apis).to.be.undefined;
+      done();
   });
 
 });


### PR DESCRIPTION
This pull request should fix the swagger output object to not include custom option keys. Specifically added a `blacklist` of keys to not include in the output object for maintainability for future options that may be added.

* Added and updated tests
* Added excluded list for key definitions that are to be removed