### PR TITLE
Fix apis name in CLI docs and error message

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -114,7 +114,7 @@ fs.readFile(program.definition, 'utf-8', function(err, data) {
   if (!swaggerDefinition.apis && !program.args.length) {
     console.log('You must provide sources for reading API files.');
     // jscs:disable maximumLineLength
-    return console.log('Either add filenames as arguments, or add an api key in your definitions file.');
+    return console.log('Either add filenames as arguments, or add an "apis" key in your definitions file.');
   }
 
   // If there's no argument passed, but the user has defined Apis in

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -13,7 +13,7 @@ $ swagger-jsdoc -h
 
 #### Specify a definition file
 
-Swagger-jsdoc will read the `api` array in your definition file by default for file paths it should read.
+Swagger-jsdoc will read the `apis` array in your definition file by default for file paths it should read.
 
 ```
 $ swagger-jsdoc -d swaggerDef.js -o doc.json


### PR DESCRIPTION
The correct key name is `apis`, not `api`.