### PR TITLE
error reporting help with new "verbose" flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,21 +101,35 @@ module.exports = function(options) {
   var apiPaths = convertGlobPaths(options.apis);
 
   // Parse the documentation in the APIs array.
-  for (var i = 0; i < apiPaths.length; i = i + 1) {
-    var files = parseApiFile(apiPaths[i]);
-    var swaggerJsDocComments = filterJsDocComments(files.jsdoc);
+  for (let i = 0; i < apiPaths.length; i += 1) {
+		try {
+			const files = parseApiFile(apiPaths[i]);
+			const swaggerJsDocComments = filterJsDocComments(files.jsdoc);
+			const problems = swaggerHelpers.findDeprecated([files, swaggerJsDocComments]);
+			// Report a warning in case potential problems encountered.
+			if (problems.length > 0) {
+				console.warn(`Problems found in ${apiPaths[i]}`);
+				console.warn('You are using properties to be deprecated in v2.0.0');
+				console.warn('Please update to align with the swagger v2.0 spec.');
+				console.warn(problems);
+			}
 
-    var problems = swaggerHelpers.findDeprecated([files, swaggerJsDocComments]);
-    // Report a warning in case potential problems encountered.
-    if (problems.length > 0) {
-      console.warn('You are using properties to be deprecated in v2.0.0');
-      console.warn('Please update to align with the swagger v2.0 spec.');
-      console.warn(problems);
-    }
-
-    swaggerHelpers.addDataToSwaggerObject(swaggerObject, files.yaml);
-    swaggerHelpers.addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
-  }
+			swaggerHelpers.addDataToSwaggerObject(swaggerObject, files.yaml);
+			swaggerHelpers.addDataToSwaggerObject(swaggerObject, swaggerJsDocComments);
+		} catch (err) {
+      if(options.verbose) {
+        let msg = err.message;
+        if (err.mark && err.mark.buffer && err.mark.line) {
+          const line = err.mark.line - 4; // why is this 4 lines off?
+          const bufferParts = err.mark.buffer.split('\n');
+          bufferParts[line] = `${bufferParts[line]} <-------------- YOUR ERROR IS HERE`;
+          msg = bufferParts.join('\n');
+        }
+        console.warn(`Failed to parse ${apiPaths[i]}\n`, msg);
+      }
+			throw err;
+		}
+	}
 
   parser.parse(swaggerObject, function(err, api) {
     if (!err) {


### PR DESCRIPTION
We were struggling to generate docs for large projects. The included made it very easy for us to debug any jsdoc issues. Before this change, we would have to dig through commit history to find where someone mistyped.