### PR TITLE
Fix misleading description

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -125,7 +125,7 @@ model and add fields.
    * @swagger
    * /users:
    *   post:
-   *     description: Returns users
+   *     description: Creates a user
    *     produces:
    *       - application/json
    *     parameters:


### PR DESCRIPTION
Obviously left over when copy/pasting from previous example, the description was wrong and didn't match what the route does.