### PR TITLE
Do not print deprecation message inside examples

### DIFF
--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -219,6 +219,16 @@ function addDataToSwaggerObject(swaggerObject, data) {
 }
 
 /**
+ * Wrong properties are allowed inside JSON schema `properties` or inside
+ * examples
+ */
+function isCustomProp(path) {
+  return path[path.length - 2] === 'properties' ||
+    path.indexOf('example') !== -1 ||
+    path.indexOf('examples') !== -1;
+}
+
+/**
  * Aggregates a list of wrong properties in problems.
  * Searches in object based on a list of wrongSet.
  * @param {Array|object} list - a list to iterate
@@ -228,10 +238,8 @@ function addDataToSwaggerObject(swaggerObject, data) {
 function seekWrong(list, wrongSet, problems) {
   var iterator = new RecursiveIterator(list, 0, false);
   for (var item = iterator.next(); !item.done; item = iterator.next()) {
-    var isDirectChildOfProperties =
-      item.value.path[item.value.path.length - 2] === 'properties';
-
-    if (wrongSet.indexOf(item.value.key) > 0 && !isDirectChildOfProperties) {
+    if (wrongSet.indexOf(item.value.key) > 0 &&
+      !isCustomProp(item.value.path)) {
       problems.push(item.value.key);
     }
   }


### PR DESCRIPTION
The following specification throws a deprecation message:

```yml
paths:
  /tags:
    get:
      responses:
        '200':
          schema:
            example:
              - tag: exampleValue
                otherAttribute: true
```

```
You are using properties to be deprecated in v2.0.0
Please update to align with the swagger v2.0 spec.
[ 'tag' ]
```

Deprecation messages should not be printed when the value is inside `example` or `examples` as it might just be that the model happened to be called (for example) `tag` (which is a common model name).