### PR TITLE
Upgrade chokidar 1.7.0 -> 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Surnet/swagger-jsdoc",
   "dependencies": {
-    "chokidar": "^1.7.0",
+    "chokidar": "^2.0.3",
     "commander": "^2.11.0",
     "doctrine": "^2.0.0",
     "glob": "^7.1.2",


### PR DESCRIPTION
This fixes half of #100

The other half depends on `fsevents`. They fixed the problem 2 weeks ago but they haven't released to `npm` yet.