### PR TITLE
Add support for jsDoc filtering

### DIFF
--- a/example/v2/envVars.js
+++ b/example/v2/envVars.js
@@ -1,0 +1,12 @@
+/*
+ * Mimics a Node server's set of environment variables
+ */
+module.exports = {
+  /*
+   * Switch between sample values of filter 'X' or 'Y'.
+   * to see display behavior in swagger-jsdoc filtering.
+   * If 'X' is defined, 'featureY' documentation should
+   * not show up in the /api-docs.json and vice-versa.
+   */
+  featureFilter: 'X',
+};

--- a/example/v2/routes2.js
+++ b/example/v2/routes2.js
@@ -14,4 +14,32 @@ module.exports.setup = function(app) {
   app.get('/hello', (req, res) => {
     res.send('Hello World (Version 2)!');
   });
+
+  /**
+   * featureX
+   * @swagger
+   * /newFeatureX:
+   *   get:
+   *     description: Part of feature X
+   *     responses:
+   *       200:
+   *         description: hello feature X
+   */
+  app.get('/newFeatureX', (req, res) => {
+    res.send('This is a new feature X!');
+  });
+
+  /**
+   * featureY
+   * @swagger
+   * /newFeatureY:
+   *   get:
+   *     description: Part of feature Y
+   *     responses:
+   *       200:
+   *         description: hello feature Y
+   */
+  app.get('/newFeatureY', (req, res) => {
+    res.send('This is another new feature Y!');
+  });
 };

--- a/lib/helpers/getSpecificationObject.js
+++ b/lib/helpers/getSpecificationObject.js
@@ -48,7 +48,7 @@ function getSpecificationObject(options) {
   const apiPaths = convertGlobPaths(options.apis);
 
   for (let i = 0; i < apiPaths.length; i += 1) {
-    const files = parseApiFile(apiPaths[i]);
+    const files = parseApiFile(apiPaths[i], options.jsDocFilter);
     const swaggerJsDocComments = filterJsDocComments(files.jsdoc);
 
     specHelper.addDataToSwaggerObject(specification, files.yaml);

--- a/lib/helpers/parseApiFile.js
+++ b/lib/helpers/parseApiFile.js
@@ -7,10 +7,11 @@ const jsYaml = require('js-yaml');
  * Parses the provided API file for JSDoc comments.
  * @function
  * @param {string} file - File to be parsed
+ * @param {object} jsDocFilter - Function returning boolean to filter docs
  * @returns {{jsdoc: array, yaml: array}} JSDoc comments and Yaml files
  * @requires doctrine
  */
-function parseApiFile(file) {
+function parseApiFile(file, jsDocFilter) {
   const jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   const fileContent = fs.readFileSync(file, { encoding: 'utf8' });
   const ext = path.extname(file);
@@ -24,7 +25,10 @@ function parseApiFile(file) {
     if (regexResults) {
       for (let i = 0; i < regexResults.length; i += 1) {
         const jsDocComment = doctrine.parse(regexResults[i], { unwrap: true });
-        jsDocComments.push(jsDocComment);
+
+        if (typeof jsDocFilter !== 'function' || !!jsDocFilter(jsDocComment)) {
+          jsDocComments.push(jsDocComment);
+        }
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,12 @@ const getSpecificationObject = require('./helpers/getSpecificationObject');
  * @requires swagger-parser
  */
 module.exports = options => {
-  if ((!options.swaggerDefinition || !options.definition) && !options.apis) {
+  if (
+    (!options.swaggerDefinition ||
+      !options.definition ||
+      !options.jsDocFilter) &&
+    !options.apis
+  ) {
     throw new Error('Provided options are incorrect.');
   }
 

--- a/test/example/v2/swagger-spec.json
+++ b/test/example/v2/swagger-spec.json
@@ -90,6 +90,16 @@
           }
         }
       }
+    },
+    "/newFeatureX": {
+      "get": {
+        "description": "Part of feature X",
+        "responses": {
+          "200": {
+            "description": "hello feature X"
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR allows support for filtering JSDocs through the use of the optional `jsDocFilter` function in order to selectively output certain documentation of choice.