### PR TITLE
refactor(helpers): remove unused functions

### DIFF
--- a/lib/helpers/specification.js
+++ b/lib/helpers/specification.js
@@ -1,8 +1,5 @@
 /* eslint no-param-reassign: 0 */
 
-// Dependencies.
-const RecursiveIterator = require('recursive-iterator');
-
 /**
  * Checks if tag is already contained withing target.
  * The tag is an object of type http://swagger.io/specification/#tagObject
@@ -172,43 +169,6 @@ function addDataToSwaggerObject(swaggerObject, data) {
   }
 }
 
-/**
- * Aggregates a list of wrong properties in problems.
- * Searches in object based on a list of wrongSet.
- * @param {Array|object} list - a list to iterate
- * @param {Array} wrongSet - a list of wrong properties
- * @param {Array} problems - aggregate list of found problems
- */
-function seekWrong(list, wrongSet, problems) {
-  const iterator = new RecursiveIterator(list, 0, true);
-  for (let item = iterator.next(); !item.done; item = iterator.next()) {
-    const isDirectChildOfProperties =
-      item.value.path[item.value.path.length - 2] === 'properties';
-
-    if (wrongSet.indexOf(item.value.key) > 0 && !isDirectChildOfProperties) {
-      problems.push(item.value.key);
-    }
-  }
-}
-
-/**
- * Returns a list of problematic tags if any.
- * @function
- * @param {Array} sources - a list of objects to iterate and check
- * @returns {Array} problems - a list of problems encountered
- */
-function findDeprecated(sources) {
-  const wrong = getSwaggerSchemaWrongProperties();
-  // accumulate problems encountered
-  const problems = [];
-  sources.forEach(source => {
-    // Iterate through `source`, search for `wrong`, accumulate in `problems`.
-    seekWrong(source, wrong, problems);
-  });
-  return problems;
-}
-
 module.exports = {
   addDataToSwaggerObject,
-  findDeprecated,
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "doctrine": "2.1.0",
     "glob": "7.1.3",
     "js-yaml": "3.12.0",
-    "recursive-iterator": "3.3.0",
     "swagger-parser": "5.0.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,10 +2284,6 @@ readable-stream@^2.0.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-recursive-iterator@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/recursive-iterator/-/recursive-iterator-3.3.0.tgz#4e498ce6227d8c42b2e2d496b296bc866c134514"
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
While reviewing #106 I found that there is no more deprecation message functionality, only the correction one.