### PR TITLE
Return false for non-empty objects

### DIFF
--- a/lib/helpers/getSpecificationObject.js
+++ b/lib/helpers/getSpecificationObject.js
@@ -6,12 +6,7 @@ const filterJsDocComments = require('./filterJsDocComments');
 const convertGlobPaths = require('./convertGlobPaths');
 
 function isEmptyObject(obj) {
-  // eslint-disable-next-line
-  Object.keys(obj).forEach(key => {
-    if (key in obj) return false;
-  });
-
-  return true;
+  return Object.keys(obj).every(key => !(key in obj));
 }
 
 /**


### PR DESCRIPTION
Currently always returns true. Should return false for non-empty objects.

Note that `Object.keys(obj).forEach(key => {	
    if (key in obj) return false;	
  });` doesn't do anything :(