### PR TITLE
Adding specification configuration documentation to GETTING-STARTED.md

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -7,6 +7,7 @@ const swaggerJSDoc = require('swagger-jsdoc');
 
 const options = {
   definition: {
+    openapi: '3.0.1', // Specification (optional, defaults to swagger: '2.0')
     info: {
       title: 'Hello World', // Title (required)
       version: '1.0.0', // Version (required)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -7,7 +7,7 @@ const swaggerJSDoc = require('swagger-jsdoc');
 
 const options = {
   definition: {
-    openapi: '3.0.1', // Specification (optional, defaults to swagger: '2.0')
+    openapi: '3.0.0', // Specification (optional, defaults to swagger: '2.0')
     info: {
       title: 'Hello World', // Title (required)
       version: '1.0.0', // Version (required)


### PR DESCRIPTION
This PR makes clear in the GETTING-STARTING.md documentation that the default specification is swagger 2.0.