### PR TITLE
Removes apis property from swaggerDefinition.

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -165,6 +165,7 @@ fs.readFile(program.definition, 'utf-8', (err, data) => {
     swaggerDefinition.apis instanceof Array
   ) {
     program.args = swaggerDefinition.apis;
+    delete swaggerDefinition.apis;
   }
 
   return createSpecification(swaggerDefinition, program.args, output);


### PR DESCRIPTION
When an `apis` property is used in the `swaggerDef.js`, it propagates to the generated `swagger.json`. Because `apis` is not a valid OpenAPI property, it does not pass Swagger's validation.

`program.args` is specified as the `apis` argument to the `createSpecification` function thus we are safe to delete it from the `swaggerDefinition` at this point.

Current
![image](https://user-images.githubusercontent.com/1657351/51996672-15a85f00-246a-11e9-9f0b-99073ceb1619.png)

Requested
![image](https://user-images.githubusercontent.com/1657351/51996819-6324cc00-246a-11e9-9f18-a40e8588352f.png)