### PR TITLE
[feat]: Add option for resolveReferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ const options = {
   apis: ['./example/v2/routes*.js'], // <-- not in the definition, but in the options
 };
 
-const swaggerSpec = swaggerJSDoc(options);
+const swaggerSpec = await swaggerJSDoc(options);
 ```
 
 ### Quick Start

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -38,3 +38,11 @@ $ swagger-jsdoc -o custom_specification.json
 ```
 
 `swagger.json` by default. Output specification can accept also a `.yaml` or `.yml`. This generated OpenAPI specification can then be further tweaked with [`swagger-editor`](http://swagger.io/swagger-editor/) or similar.
+
+#### Resolve references (optional)
+
+```
+$ swagger-jsdoc --resolveReferences
+```
+
+When specified, it will attempt to resolve any `$ref`s in the output. That means content from defined source will be copied into the reference. This is useful if the code consuming the output file doesn't properly understand `$ref`s.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -18,7 +18,7 @@ const options = {
 };
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
-const swaggerSpec = swaggerJSDoc(options);
+const swaggerSpec = await swaggerJSDoc(options);
 ```
 
 Notes:

--- a/example/v2/app.js
+++ b/example/v2/app.js
@@ -43,25 +43,28 @@ const options = {
 };
 
 // Initialize swagger-jsdoc -> returns validated swagger spec in json format
-const swaggerSpec = swaggerJSDoc(options);
+swaggerJSDoc(options).then(swaggerSpec => {
+  // Serve swagger docs the way you like (Recommendation: swagger-tools)
+  app.get('/api-docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(swaggerSpec);
+  });
 
-// Serve swagger docs the way you like (Recommendation: swagger-tools)
-app.get('/api-docs.json', (req, res) => {
-  res.setHeader('Content-Type', 'application/json');
-  res.send(swaggerSpec);
+  // Set up the routes
+  routes.setup(app);
+  routes2.setup(app);
+
+  // Expose app
+  module.exports = app;
+
+  // Start the server
+  const server = app.listen(PORT, () => {
+    const host = server.address().address;
+    const { port } = server.address();
+
+    console.log('Example app listening at http://%s:%s', host, port);
+  });
 });
-
-// Set up the routes
-routes.setup(app);
-routes2.setup(app);
 
 // Expose app
 module.exports = app;
-
-// Start the server
-const server = app.listen(PORT, () => {
-  const host = server.address().address;
-  const { port } = server.address();
-
-  console.log('Example app listening at http://%s:%s', host, port);
-});

--- a/example/v2/routes.js
+++ b/example/v2/routes.js
@@ -34,6 +34,17 @@ module.exports.setup = function(app) {
 
   /**
    * @swagger
+   *  parameters:
+   *    username:
+   *      name: username
+   *      description: Username to use for login
+   *      in: formData
+   *      required: true
+   *      type: string
+   */
+
+  /**
+   * @swagger
    * tags:
    *   name: Users
    *   description: User management and login

--- a/lib/helpers/getSpecificationObject.js
+++ b/lib/helpers/getSpecificationObject.js
@@ -1,4 +1,5 @@
 const parser = require('swagger-parser');
+const jsonRefs = require('json-refs');
 const createSpecification = require('./createSpecification');
 const specHelper = require('./specification');
 const parseApiFile = require('./parseApiFile');
@@ -31,7 +32,7 @@ function cleanUselessProperties(inputSpec) {
   return improvedSpec;
 }
 
-function getSpecificationObject(options) {
+async function getSpecificationObject(options) {
   // Get input definition and prepare the specification's skeleton
   const definition = options.swaggerDefinition || options.definition;
   let specification = createSpecification(definition);
@@ -55,6 +56,10 @@ function getSpecificationObject(options) {
 
   if (specification.openapi) {
     specification = cleanUselessProperties(specification);
+  }
+
+  if (options.resolveReferences) {
+    specification = (await jsonRefs.resolveRefs(specification)).resolved;
   }
 
   return specification;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,13 +9,13 @@ const getSpecificationObject = require('./helpers/getSpecificationObject');
  * @returns {object} Output specification
  * @requires swagger-parser
  */
-module.exports = options => {
+module.exports = async options => {
   if ((!options.swaggerDefinition || !options.definition) && !options.apis) {
     throw new Error('Provided options are incorrect.');
   }
 
   try {
-    const specificationObject = getSpecificationObject(options);
+    const specificationObject = await getSpecificationObject(options);
 
     return specificationObject;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "doctrine": "2.1.0",
     "glob": "7.1.3",
     "js-yaml": "3.12.0",
+    "json-refs": "^3.0.12",
     "swagger-parser": "5.0.5"
   },
   "devDependencies": {

--- a/test/cli/cli.js
+++ b/test/cli/cli.js
@@ -103,6 +103,31 @@ describe('command line interface', () => {
       const specification = fs.statSync('swagger.json');
       // Check that the physical file was created.
       expect(specification.nlink).to.be.above(0);
+
+      const contents = fs.readFileSync('swagger.json', 'utf-8');
+      expect(contents).to.contain('$ref');
+      done();
+    });
+  });
+
+  it('should resolve references when specified', done => {
+    const goodInput = `${
+      process.env.PWD
+    }/bin/swagger-jsdoc.js --resolveReferences -d example/v2/swaggerDef.js example/v2/routes.js`;
+    exec(goodInput, (error, stdout, stderr) => {
+      if (error) {
+        throw new Error(error, stderr);
+      }
+      expect(stdout).to.contain('Swagger specification is ready.');
+      expect(stderr).to.not.contain(
+        'You are using properties to be deprecated'
+      );
+      const specification = fs.statSync('swagger.json');
+      // Check that the physical file was created.
+      expect(specification.nlink).to.be.above(0);
+
+      const contents = fs.readFileSync('swagger.json', 'utf-8');
+      expect(contents).not.to.contain('$ref');
       done();
     });
   });

--- a/test/example/v3/test.js
+++ b/test/example/v3/test.js
@@ -22,7 +22,7 @@ const tests = ['api-with-examples', 'callback', 'links', 'petstore'];
 
 describe('OpenAPI examples', () => {
   tests.forEach(test => {
-    it(`Example: ${test}`, done => {
+    it(`Example: ${test}`, async () => {
       const title = `Sample specification testing ${test}`;
 
       // eslint-disable-next-line
@@ -43,10 +43,36 @@ describe('OpenAPI examples', () => {
         apis: [`./test/example/v3/${test}/api.js`],
       };
 
-      const specification = swaggerJsdoc(options);
+      const specification = await swaggerJsdoc(options);
       expect(specification).to.matchSnapshot();
       expect(specification).to.eql(referenceSpecification);
-      done();
+    });
+
+    it(`Example: ${test} --resolveReferences`, async () => {
+      const title = `Sample specification testing ${test}`;
+
+      // eslint-disable-next-line
+      const referenceSpecification = require(path.resolve(
+        `${__dirname}/${test}/openapi.json`
+      ));
+
+      const definition = {
+        openapi: '3.0.0',
+        info: {
+          version: '1.0.0',
+          title,
+        },
+      };
+
+      const options = {
+        definition,
+        apis: [`./test/example/v3/${test}/api.js`],
+        resolveReferences: true,
+      };
+
+      const specification = await swaggerJsdoc(options);
+      const json = JSON.stringify(specification, null, 2);
+      expect(json).to.not.contain('$ref');
     });
   });
 });

--- a/test/helpers/specification-helpers.js
+++ b/test/helpers/specification-helpers.js
@@ -65,7 +65,7 @@ describe('swagger-helpers submodule', () => {
     done();
   });
 
-  it('paths should not override each other', done => {
+  it('paths should not override each other', async () => {
     // eslint-disable-next-line
     const swagger = require('../../lib');
 
@@ -74,9 +74,8 @@ describe('swagger-helpers submodule', () => {
       apis: ['./**/*/external/*.yml'],
     };
 
-    testObject = swagger(testObject);
+    testObject = await swagger(testObject);
     expect(testObject.responses.api).to.include.keys(['foo', 'bar']);
-    done();
   });
 
   it('hasEmptyProperty() identifies object with an empty object or array as property', done => {

--- a/test/unit/open-api.js
+++ b/test/unit/open-api.js
@@ -16,7 +16,7 @@ beforeEach(function() {
 });
 
 describe('OpenAPI specification compatiblity', () => {
-  it('The new openapi property is respected', done => {
+  it('The new openapi property is respected', async () => {
     // eslint-disable-next-line
     const swaggerJsdoc = require('../../lib');
 
@@ -52,8 +52,7 @@ describe('OpenAPI specification compatiblity', () => {
       apis: [],
     };
 
-    const specification = swaggerJsdoc(options);
+    const specification = await swaggerJsdoc(options);
     expect(specification).to.matchSnapshot();
-    done();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,6 +381,11 @@ commander@2.17.1, commander@^2.14.1, commander@^2.7.1, commander@^2.9.0:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
+commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -990,9 +995,10 @@ format-util@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.3.tgz#032dca4a116262a12c43f4c3ec8566416c5b2d95"
 
-formidable@^1.1.1:
+formidable@^1.1.1, formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -1084,6 +1090,13 @@ globby@^5.0.0:
 graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graphlib@^2.1.1:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.7.tgz#b6a69f9f44bd9de3963ce6804a2fc9e73d86aecc"
+  integrity sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==
+  dependencies:
+    lodash "^4.17.5"
 
 growl@1.10.5:
   version "1.10.5"
@@ -1486,9 +1499,31 @@ js-yaml@3.12.0, js-yaml@^3.12.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.10.0:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
+  integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
+json-refs@^3.0.12:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/json-refs/-/json-refs-3.0.12.tgz#949435968974bcc9f4b515a97036aa912700d067"
+  integrity sha512-6RbO1Y3e0Hty/tEpXtQG6jUx7g1G8e39GIOuPugobPC8BX1gZ0OGZQpBn1FLWGkuWF35GRGADvhwdEIFpwIjyA==
+  dependencies:
+    commander "~2.11.0"
+    graphlib "^2.1.1"
+    js-yaml "^3.10.0"
+    lodash "^4.17.4"
+    native-promise-only "^0.8.1"
+    path-loader "^1.0.5"
+    slash "^1.0.0"
+    uri-js "^3.0.2"
 
 json-schema-ref-parser@^5.1.3:
   version "5.1.3"
@@ -1843,6 +1878,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+  integrity sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2086,6 +2126,14 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-loader@^1.0.5:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/path-loader/-/path-loader-1.0.9.tgz#4f204ada1a477db2a572fce382029c3f24dc5237"
+  integrity sha512-pD37gArtr+/72Tst9oJoDB9k7gB9A09Efj7yyBi5HDUqaxqULXBWW8Rnw2TfNF+3sN7QZv0ZNdW1Qx2pFGW5Jg==
+  dependencies:
+    native-promise-only "^0.8.1"
+    superagent "^3.8.3"
+
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -2272,9 +2320,10 @@ read-pkg@^4.0.1:
     parse-json "^4.0.0"
     pify "^3.0.0"
 
-readable-stream@^2.0.5:
+readable-stream@^2.0.5, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -2465,6 +2514,11 @@ shell-quote@^1.6.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slash@^2.0.0:
   version "2.0.0"
@@ -2668,6 +2722,22 @@ superagent@3.8.2:
     qs "^6.5.1"
     readable-stream "^2.0.5"
 
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
 supertest@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.1.0.tgz#f9ebaf488e60f2176021ec580bdd23ad269e7bc6"
@@ -2803,6 +2873,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+uri-js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-3.0.2.tgz#f90b858507f81dea4dcfbb3c4c3dbfa2b557faaa"
+  integrity sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=
+  dependencies:
+    punycode "^2.1.0"
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
BREAKING CHANGE: API is now promise based

I've hit some issues where sometimes code doesn't fully understand the `$ref`s in a proper way and they need to be dereferenced.  In particular AWS's API Gateway doesn't seem to like parameter refs.  As a work around, I've been able to run the output swagger file through a tool to dereference the references. It seemed like a nice addition to this library.

Unfortunately since the API for swagger-jsdoc generation is synchronous and dereferencing needs to be asynchronous (it could be a remote reference), that necessitated changing the API here to be asynchronous, and I opted for a promise-based API over node-style callbacks, but I could change that if that'd be preferred.