### PR TITLE
Updating js-yaml dependency to 3.13.1 to fix remote execution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "commander": "2.17.1",
     "doctrine": "2.1.0",
     "glob": "7.1.3",
-    "js-yaml": "3.13.0",
+    "js-yaml": "3.13.1",
     "swagger-parser": "5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a vulnerability in 3.13.0.

I made a simple change but would suggest to accept wildcards for dependencies to be able to automatically solve these.