### PR TITLE
refactor(parser): expose specification builder methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ If you prefer to write the OpenAPI specification first and separately, you might
 - [swagger-editor](http://swagger.io/swagger-editor/)
 - [swagger-node](https://github.com/swagger-api/swagger-node)
 
+### Webpack integration
+
+You can use this package with a webpack plugin to keep your swagger documentation up-to-date when building your app:
+
+- [swagger-jsdoc-webpack-plugin](https://github.com/patsimm/swagger-jsdoc-webpack-plugin) - Rebuild the swagger definition based on a predefined list of files on each webpack build.
+- [swagger-jsdoc-sync-webpack-plugin](https://github.com/gautier-lefebvre/swagger-jsdoc-sync-webpack-plugin) - Rebuild the swagger definition based on the files imported in your app on each webpack build.
+
 ## Supported versions
 
 - OpenAPI 3.x

--- a/lib/helpers/finalizeSpecificationObject.js
+++ b/lib/helpers/finalizeSpecificationObject.js
@@ -1,0 +1,51 @@
+const parser = require('swagger-parser');
+const hasEmptyProperty = require('./hasEmptyProperty');
+
+/**
+ * OpenAPI specification validator does not accept empty values for a few properties.
+ * Solves validator error: "Schema error should NOT have additional properties"
+ * @function
+ * @param {object} inputSpec - The swagger/openapi specification
+ * @param {object} improvedSpec - The cleaned version of the inputSpec
+ */
+function cleanUselessProperties(inputSpec) {
+  const improvedSpec = JSON.parse(JSON.stringify(inputSpec));
+  const toClean = [
+    'definitions',
+    'responses',
+    'parameters',
+    'securityDefinitions',
+  ];
+
+  toClean.forEach(unnecessaryProp => {
+    if (hasEmptyProperty(improvedSpec[unnecessaryProp])) {
+      delete improvedSpec[unnecessaryProp];
+    }
+  });
+
+  return improvedSpec;
+}
+
+/**
+ * Parse the swagger object and remove useless properties if necessary.
+ *
+ * @param {object} swaggerObject - Swagger object from parsing the api files.
+ * @returns {object} The specification.
+ */
+function finalizeSpecificationObject(swaggerObject) {
+  let specification = swaggerObject;
+
+  parser.parse(swaggerObject, (err, api) => {
+    if (!err) {
+      specification = api;
+    }
+  });
+
+  if (specification.openapi) {
+    specification = cleanUselessProperties(specification);
+  }
+
+  return specification;
+}
+
+module.exports = finalizeSpecificationObject;

--- a/lib/helpers/getSpecificationObject.js
+++ b/lib/helpers/getSpecificationObject.js
@@ -1,63 +1,23 @@
-const parser = require('swagger-parser');
 const createSpecification = require('./createSpecification');
-const specHelper = require('./specification');
 const parseApiFile = require('./parseApiFile');
-const filterJsDocComments = require('./filterJsDocComments');
 const convertGlobPaths = require('./convertGlobPaths');
-const hasEmptyProperty = require('./hasEmptyProperty');
-
-/**
- * OpenAPI specification validator does not accept empty values for a few properties.
- * Solves validator error: "Schema error should NOT have additional properties"
- * @function
- * @param {object} inputSpec - The swagger/openapi specification
- * @param {object} improvedSpec - The cleaned version of the inputSpec
- */
-function cleanUselessProperties(inputSpec) {
-  const improvedSpec = JSON.parse(JSON.stringify(inputSpec));
-  const toClean = [
-    'definitions',
-    'responses',
-    'parameters',
-    'securityDefinitions',
-  ];
-
-  toClean.forEach(unnecessaryProp => {
-    if (hasEmptyProperty(improvedSpec[unnecessaryProp])) {
-      delete improvedSpec[unnecessaryProp];
-    }
-  });
-
-  return improvedSpec;
-}
+const finalizeSpecificationObject = require('./finalizeSpecificationObject');
+const updateSpecificationObject = require('./updateSpecificationObject');
 
 function getSpecificationObject(options) {
   // Get input definition and prepare the specification's skeleton
   const definition = options.swaggerDefinition || options.definition;
-  let specification = createSpecification(definition);
+  const specification = createSpecification(definition);
 
   // Parse the documentation containing information about APIs.
   const apiPaths = convertGlobPaths(options.apis);
 
   for (let i = 0; i < apiPaths.length; i += 1) {
-    const files = parseApiFile(apiPaths[i]);
-    const swaggerJsDocComments = filterJsDocComments(files.jsdoc);
-
-    specHelper.addDataToSwaggerObject(specification, files.yaml);
-    specHelper.addDataToSwaggerObject(specification, swaggerJsDocComments);
+    const parsedFile = parseApiFile(apiPaths[i]);
+    updateSpecificationObject(parsedFile, specification);
   }
 
-  parser.parse(specification, (err, api) => {
-    if (!err) {
-      specification = api;
-    }
-  });
-
-  if (specification.openapi) {
-    specification = cleanUselessProperties(specification);
-  }
-
-  return specification;
+  return finalizeSpecificationObject(specification);
 }
 
 module.exports = getSpecificationObject;

--- a/lib/helpers/parseApiFile.js
+++ b/lib/helpers/parseApiFile.js
@@ -1,38 +1,17 @@
 const fs = require('fs');
 const path = require('path');
-const doctrine = require('doctrine');
-const jsYaml = require('js-yaml');
-
+const parseApiFileContent = require('./parseApiFileContent');
 /**
  * Parses the provided API file for JSDoc comments.
  * @function
  * @param {string} file - File to be parsed
  * @returns {{jsdoc: array, yaml: array}} JSDoc comments and Yaml files
- * @requires doctrine
  */
 function parseApiFile(file) {
-  const jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
   const fileContent = fs.readFileSync(file, { encoding: 'utf8' });
   const ext = path.extname(file);
-  const yaml = [];
-  const jsDocComments = [];
 
-  if (ext === '.yaml' || ext === '.yml') {
-    yaml.push(jsYaml.safeLoad(fileContent));
-  } else {
-    const regexResults = fileContent.match(jsDocRegex);
-    if (regexResults) {
-      for (let i = 0; i < regexResults.length; i += 1) {
-        const jsDocComment = doctrine.parse(regexResults[i], { unwrap: true });
-        jsDocComments.push(jsDocComment);
-      }
-    }
-  }
-
-  return {
-    yaml,
-    jsdoc: jsDocComments,
-  };
+  return parseApiFileContent(fileContent, ext);
 }
 
 module.exports = parseApiFile;

--- a/lib/helpers/parseApiFileContent.js
+++ b/lib/helpers/parseApiFileContent.js
@@ -1,0 +1,36 @@
+const doctrine = require('doctrine');
+const jsYaml = require('js-yaml');
+
+/**
+ * Parse the provided API file content.
+ *
+ * @function
+ * @param {string} fileContent - Content of the file
+ * @param {string} ext - File format ('.yaml', '.yml', '.js', etc.)
+ * @returns {{jsdoc: array, yaml: array}} JSDoc comments and Yaml files
+ * @requires doctrine
+ */
+function parseApiFileContent(fileContent, ext) {
+  const jsDocRegex = /\/\*\*([\s\S]*?)\*\//gm;
+  const yaml = [];
+  const jsDocComments = [];
+
+  if (ext === '.yaml' || ext === '.yml') {
+    yaml.push(jsYaml.safeLoad(fileContent));
+  } else {
+    const regexResults = fileContent.match(jsDocRegex);
+    if (regexResults) {
+      for (let i = 0; i < regexResults.length; i += 1) {
+        const jsDocComment = doctrine.parse(regexResults[i], { unwrap: true });
+        jsDocComments.push(jsDocComment);
+      }
+    }
+  }
+
+  return {
+    yaml,
+    jsdoc: jsDocComments,
+  };
+}
+
+module.exports = parseApiFileContent;

--- a/lib/helpers/updateSpecificationObject.js
+++ b/lib/helpers/updateSpecificationObject.js
@@ -1,0 +1,20 @@
+const specHelper = require('./specification');
+const filterJsDocComments = require('./filterJsDocComments');
+
+/**
+ * Given an api file parsed for its jsdoc comments and yaml files, update the
+ * specification.
+ *
+ * @param {object} parsedFile - Parsed API file.
+ * @param {object} specification - Specification accumulator.
+ */
+function updateSpecificationObject(parsedFile, specification) {
+  specHelper.addDataToSwaggerObject(specification, parsedFile.yaml);
+
+  specHelper.addDataToSwaggerObject(
+    specification,
+    filterJsDocComments(parsedFile.jsdoc)
+  );
+}
+
+module.exports = updateSpecificationObject;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,11 @@
 
 const getSpecificationObject = require('./helpers/getSpecificationObject');
 
+const createSpecification = require('./helpers/createSpecification');
+const parseApiFileContent = require('./helpers/parseApiFileContent');
+const updateSpecificationObject = require('./helpers/updateSpecificationObject');
+const finalizeSpecificationObject = require('./helpers/finalizeSpecificationObject');
+
 /**
  * Generates the specification.
  * @function
@@ -32,3 +37,8 @@ module.exports = options => {
     throw new Error(err);
   }
 };
+
+module.exports.createSpecification = createSpecification;
+module.exports.parseApiFileContent = parseApiFileContent;
+module.exports.updateSpecificationObject = updateSpecificationObject;
+module.exports.finalizeSpecificationObject = finalizeSpecificationObject;


### PR DESCRIPTION
Hello,

I'm trying to use this module to create a webpack plugin that updates the swagger.json specification every time the code changes, but the way it is written now is not compatible with the way webpack works. In `getSpecificationObject`, it uses a glob pattern to read files on disk, while webpack will give me the file content in memory.

So this PR simply refactors the `parseApiFile` and `getSpecificationObject` functions and exposes other methods to handle the api files in memory as well as on disk. I avoided breaking changes, it still works the same way for the classic use case.