### PR TITLE
Enable '@openapi' annotation for spec comments

### DIFF
--- a/lib/helpers/filterJsDocComments.js
+++ b/lib/helpers/filterJsDocComments.js
@@ -14,7 +14,7 @@ function filterJsDocComments(jsDocComments) {
     const jsDocComment = jsDocComments[i];
     for (let j = 0; j < jsDocComment.tags.length; j += 1) {
       const tag = jsDocComment.tags[j];
-      if (tag.title === 'swagger') {
+      if (tag.title === 'swagger' || tag.title === 'openapi' ) {
         swaggerJsDocComments.push(jsYaml.safeLoad(tag.description));
       }
     }


### PR DESCRIPTION
Since the specification has been renamed to [OpenAPI](https://swagger.io/specification/) I thought it would be appropriate to allow for `@openapi` annotation in addition to using `@swagger`.

```ts
/**
 * @openapi
 * /example:
 *   get:
 *     summary: "Get all"
 *     responses:
 *       200:
 *         description: OK
 */
```

I only changed a single if statement, I have no clue if this change would impact other area's of the code as well. If additional changes are required, please point me in the right direction.