### PR TITLE
Better describing errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,12 @@ const finalizeSpecificationObject = require('./helpers/finalizeSpecificationObje
  * @requires swagger-parser
  */
 module.exports = (options) => {
-  if ((!options.swaggerDefinition || !options.definition) && !options.apis) {
-    throw new Error('Provided options are incorrect.');
+  if (!options.swaggerDefinition && !options.definition) {
+    throw new Error(
+      'Provided swaggerDefinition or definition attributes are incorrect.'
+    );
+  } else if (!options.apis) {
+    throw new Error('Provided apis attribute are incorrect.');
   }
 
   try {


### PR DESCRIPTION
Using swagger-jsdoc for the first time, I had trouble identifying that I wasn't passing the swaggerDefinition attribute.

With these changes it became more clearer the identification of the reported error.