### PR TITLE
Remove 'api' attr from swagger definition

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -62,10 +62,10 @@ if (
 }
 
 // Continue only if arguments provided.
-if (!swaggerDefinition.apis && !program.args.length) {
+if (!program.args.length) {
   console.log('You must provide sources for reading API files.');
   console.log(
-    'Either add filenames as arguments, or add an "apis" key in your definitions file.'
+    'Either add filenames as arguments, or add an "apis" key in your configuration.'
   );
   process.exit();
 }
@@ -75,7 +75,7 @@ fs.writeFileSync(
   JSON.stringify(
     swaggerJsdoc({
       swaggerDefinition,
-      apis: swaggerDefinition.apis || program.args,
+      apis: program.args,
     }),
     null,
     2

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,17 +22,17 @@ swagger-jsdoc -h
 
 ### Definition file
 
-By default, the library will read the `apis` array from your definition file:
+Adding `-d` parameter you can speciify easily a definition file.
 
 ```bash
-swagger-jsdoc -d swaggerDefinition.js
+swagger-jsdoc -d swaggerDefinition.js route*.js component*.yaml
 ```
 
 This could be any `.js`, `.json`, `.yml` or `.yaml` extensions.
 
 ### Input files (optional)
 
-When you don't want to or can't pass `apis` from the definition above, specify like following:
+Except the `definition file` mostly you would like to add `apis` definitions to swagger. You can specify it like following:
 
 One by one:
 
@@ -55,7 +55,7 @@ These paths are relative to current directory from where `swagger-jsdoc` is ran,
 The output is `swagger.json` by default, but can be changed:
 
 ```bash
-swagger-jsdoc -d swaggerDefinition.js -o my_spec.json
+swagger-jsdoc -d swaggerDefinition.js route1.js -o my_spec.json
 ```
 
 When `.yaml` or `.yml` extension is used, the specification will be parsed and saved in YAML.

--- a/example/yaml-anchors-aliases/yaml-anchors-aliases.spec.js
+++ b/example/yaml-anchors-aliases/yaml-anchors-aliases.spec.js
@@ -15,7 +15,6 @@ describe('Example for using anchors and aliases in YAML documents', () => {
         './example/yaml-anchors-aliases/example.js',
       ],
     });
-
     expect(result).toEqual(referenceSpecification);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swagger-jsdoc",
   "description": "Generates swagger doc based on JSDoc",
-  "version": "6.0.0-rc.3",
+  "version": "6.0.0-rc.4",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/src/specification.js
+++ b/src/specification.js
@@ -235,15 +235,18 @@ function build(options) {
       });
     }
 
-    // Place to provide feedback for errors. Previously throwing, now reporting only.
-    console.info(
-      'Not all input has been taken into account at your final specification.'
-    );
-    const errReport = yamlDocsErrors.map((documentWithErrors) => {
-      const { errors } = documentWithErrors;
-      return errors.join('\n');
-    });
-    console.error(`Here's the report: \n\n\n ${errReport}`);
+    const errReport = yamlDocsErrors
+      .map(({ errors }) => errors.join('\n'))
+      .filter((error) => !!error);
+
+    if (errReport.length) {
+      // Place to provide feedback for errors. Previously throwing, now reporting only.
+      console.info(
+        'Not all input has been taken into account at your final specification.'
+      );
+
+      console.error(`Here's the report: \n\n\n ${errReport}`);
+    }
   }
 
   for (const document of yamlDocsReady) {

--- a/test/__snapshots__/cli.spec.js.snap
+++ b/test/__snapshots__/cli.spec.js.snap
@@ -75,7 +75,7 @@ More at http://swagger.io/specification/#infoObject
 
 exports[`CLI module should require arguments with jsDoc data about an API 1`] = `
 "You must provide sources for reading API files.
-Either add filenames as arguments, or add an \\"apis\\" key in your definitions file.
+Either add filenames as arguments, or add an \\"apis\\" key in your configuration.
 "
 `;
 

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -47,7 +47,9 @@ describe('CLI module', () => {
   });
 
   it('should create swagger.json by default when the API input is from definition file', async () => {
-    const result = await sh(`${bin} -d test/files/v2/api_definition.js`);
+    const result = await sh(
+      `${bin} -d test/files/v2/api_definition.js example/app/routes.js`
+    );
     expect(result.stdout).toBe('Swagger specification is ready.\n');
     const specification = fs.statSync('swagger.json');
     expect(specification.nlink).not.toBe(0);
@@ -72,21 +74,27 @@ describe('CLI module', () => {
   });
 
   it('should allow a JavaScript definition file', async () => {
-    const result = await sh(`${bin} -d test/files/v2/api_definition.js`);
+    const result = await sh(
+      `${bin} -d test/files/v2/api_definition.js example/app/routes.js`
+    );
     expect(result.stdout).toBe('Swagger specification is ready.\n');
     const specification = fs.statSync('swagger.json');
     expect(specification.nlink).not.toBe(0);
   });
 
   it('should allow a JSON definition file', async () => {
-    const result = await sh(`${bin} -d test/files/v2/api_definition.json`);
+    const result = await sh(
+      `${bin} -d test/files/v2/api_definition.json example/app/routes.js`
+    );
     expect(result.stdout).toBe('Swagger specification is ready.\n');
     const specification = fs.statSync('swagger.json');
     expect(specification.nlink).not.toBe(0);
   });
 
   it('should allow a YAML definition file', async () => {
-    const result = await sh(`${bin} -d test/files/v2/api_definition.yaml`);
+    const result = await sh(
+      `${bin} -d test/files/v2/api_definition.yaml example/app/routes.js`
+    );
     expect(result.stdout).toBe('Swagger specification is ready.\n');
     const specification = fs.statSync('swagger.json');
     expect(specification.nlink).not.toBe(0);
@@ -106,6 +114,7 @@ describe('CLI module', () => {
     const result = await sh(
       `${bin} -d example/app/swaggerDefinition.js test/files/v2/wrong-yaml-identation.js`
     );
+
     expect(result.stdout).toContain(
       'Not all input has been taken into account at your final specification.'
     );

--- a/test/files/v2/api_definition.js
+++ b/test/files/v2/api_definition.js
@@ -7,5 +7,4 @@ module.exports = {
     version: '1.0.0', // Version (required)
     description: 'A sample API', // Description (optional)
   },
-  apis: ['./**/*/routes.js'],
 };

--- a/test/files/v2/api_definition.json
+++ b/test/files/v2/api_definition.json
@@ -3,6 +3,5 @@
     "title": "Hello World",
     "version": "1.0.0",
     "description": "A sample API"
-  },
-  "apis": ["./**/*/routes.js"]
+  }
 }

--- a/test/files/v2/api_definition.yaml
+++ b/test/files/v2/api_definition.yaml
@@ -2,4 +2,3 @@ info:
   title: Hello World
   version: 1.0.0
   description: A sample API
-apis: [./**/*/routes.js]


### PR DESCRIPTION
Fix the problem with not necessary `api` attribute inside the `swaggerDefinition` file:
Issue: https://github.com/Surnet/swagger-jsdoc/issues/233