### PR TITLE
Issue with error message when using deprecated "apis" key

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -65,9 +65,6 @@ if (
 // Continue only if arguments provided.
 if (!program.args.length) {
   console.log('You must provide sources for reading API files.');
-  console.log(
-    'Add filenames as arguments (note that the "apis" key in the configuration is not read anymore).'
-  );
   process.exit();
 }
 

--- a/test/__snapshots__/cli.spec.js.snap
+++ b/test/__snapshots__/cli.spec.js.snap
@@ -75,7 +75,7 @@ More at http://swagger.io/specification/#infoObject
 
 exports[`CLI module should require arguments with jsDoc data about an API 1`] = `
 "You must provide sources for reading API files.
-Either add filenames as arguments, or add an \\"apis\\" key in your configuration.
+Add filenames as arguments (note that the \\"apis\\" key in the configuration is not read anymore).
 "
 `;
 

--- a/test/__snapshots__/cli.spec.js.snap
+++ b/test/__snapshots__/cli.spec.js.snap
@@ -75,7 +75,6 @@ More at http://swagger.io/specification/#infoObject
 
 exports[`CLI module should require arguments with jsDoc data about an API 1`] = `
 "You must provide sources for reading API files.
-Add filenames as arguments (note that the \\"apis\\" key in the configuration is not read anymore).
 "
 `;
 


### PR DESCRIPTION
Hi,

The CLI was still displaying a reference to the "apis" key when no source files were provided on the command line. I think the new message is more informative.