### PR TITLE
JSON is also valid YAML

### DIFF
--- a/packages/lib/src/utils.js
+++ b/packages/lib/src/utils.js
@@ -64,6 +64,7 @@ export async function extractAnnotations(filePath, encoding = 'utf8') {
   switch (ext) {
     case '.yml':
     case '.yaml':
+    case '.json':
       yaml.push(fileContent);
       break;
 


### PR DESCRIPTION
Since YAML is a superset of JSON, we can also accept json files here.