### PR TITLE
feat: accept 'apis' on cli defs

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -64,7 +64,7 @@ if (
 }
 
 // Continue only if arguments provided.
-if (!program.args.length) {
+if (!program.args.length && !('apis' in swaggerDefinition)) {
   console.log('You must provide sources for reading API files.');
   process.exit();
 }
@@ -73,7 +73,7 @@ const format = path.extname(output);
 
 const result = swaggerJsdoc({
   swaggerDefinition,
-  apis: program.args,
+  apis: swaggerDefinition.apis || program.args,
   format,
 });
 


### PR DESCRIPTION
Accept `apis` defition on config using `cli`

`npx swagger-jsdoc -d swagger-defs.js`

```javascript
// swagger-defs.js
module.exports = {
  info: {
    title: 'Hi',
    version,
    description: 'Lorem ipsum',
  },
  hosts: 'example.com',
  basePath: '/',
  apis: ['./src/handlers/users/**.ts']
}
```