### PR TITLE
add channels root property only for asyncapi

### DIFF
--- a/src/specification.js
+++ b/src/specification.js
@@ -137,8 +137,14 @@ function organize(swaggerObject, annotation, property) {
     'responses',
     'parameters',
     'definitions',
-    'channels',
   ];
+  
+  // include required field channels only for asyncapi specification
+  // see https://www.asyncapi.com/docs/specifications/v2.3.0
+  if (swaggerObject.asyncapi) {
+    commonProperties.push('channels');
+  }
+  
   if (commonProperties.includes(property)) {
     for (const definition of Object.keys(annotation[property])) {
       swaggerObject[property][definition] = mergeDeep(

--- a/src/specification.js
+++ b/src/specification.js
@@ -106,6 +106,12 @@ function finalize(swaggerObject, options) {
   if (specification.openapi) {
     specification = clean(specification);
   }
+  
+  // required field channels is only present in asyncapi specification
+  // see https://www.asyncapi.com/docs/specifications/v2.3.0
+  if (specification.openapi || specification.swagger) {
+    delete specification.channels;
+  }
 
   return format(specification, options.format);
 }
@@ -137,14 +143,8 @@ function organize(swaggerObject, annotation, property) {
     'responses',
     'parameters',
     'definitions',
+    'channels',
   ];
-  
-  // include required field channels only for asyncapi specification
-  // see https://www.asyncapi.com/docs/specifications/v2.3.0
-  if (swaggerObject.asyncapi) {
-    commonProperties.push('channels');
-  }
-  
   if (commonProperties.includes(property)) {
     for (const definition of Object.keys(annotation[property])) {
       swaggerObject[property][definition] = mergeDeep(


### PR DESCRIPTION
fixes #314  
The root property `channels` are only present in the `asyncapi` specification.  
See https://www.asyncapi.com/docs/specifications/v2.3.0
This fix adds `channels` to the `commonProperties` array only when `swaggerObject.asyncapi` is present.