### PR TITLE
docs: add section for failOnErrors option flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ yarn add swagger-jsdoc
 - Swagger 2
 - AsyncAPI 2.0
 
+## Validation of swagger docs
+
+By default `swagger-jsdoc` tries to parse all docs to it's best capabilities. If you'd like to you can instruct an Error to be thrown instead if validation failed by setting the options flag `failOnErrors` to `true`. This is for instance useful if you want to verify that your swagger docs validate using a unit test.
+
+```javascript
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+  failOnErrors: true, // Whether or not to throw when parsing errors. Defaults to false.
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Hello World',
+      version: '1.0.0',
+    },
+  },
+  apis: ['./src/routes*.js'],
+};
+
+const openapiSpecification = swaggerJsdoc(options);
+```
+
 ## Documentation
 
 Click on the version you are using for further details:


### PR DESCRIPTION
I found this option by accident when digging through the source. Therefore I wrote some docs about this flag and a use case where it would be useful.