### PR TITLE
Fixes cleaned up errors still logging doc path.

### DIFF
--- a/src/specification.js
+++ b/src/specification.js
@@ -278,6 +278,7 @@ function build(options) {
 
     // Format errors into a printable/throwable string
     const errReport = yamlDocsErrors
+      .filter((doc) => doc.errors.length)
       .map(({ errors, filePath }) => {
         let str = `Error in ${filePath} :\n`;
         if (options.verbose) {


### PR DESCRIPTION
Small one.
The old code cleans up `YAMLReferenceError`s but will still log `Error in ${filePath} :\n` when all errors for the doc has been cleaned away.

This is a fix for that behaviour.  

And thanks for a great package!