### PR TITLE
docs: add double wildcards to more general solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const options = {
       version: '1.0.0',
     },
   },
-  apis: ['./src/routes*.js'], // files containing annotations as above
+  apis: ['**/src/routes*.js'], // files containing annotations as above
 };
 
 const openapiSpecification = swaggerJsdoc(options);
@@ -87,7 +87,7 @@ const options = {
       version: '1.0.0',
     },
   },
-  apis: ['./src/routes*.js'],
+  apis: ['**/src/routes*.js'],
 };
 
 const openapiSpecification = swaggerJsdoc(options);


### PR DESCRIPTION
When your code is in the `src` folder but your `index.js` is in before it your code will work, otherwise, if your `index.js` is in the same folder `src`, it will not.