### PR TITLE
Fixes cleaned up errors still logging doc path

### DIFF
--- a/examples/yaml-anchors-aliases/yaml-anchors-aliases.spec.js
+++ b/examples/yaml-anchors-aliases/yaml-anchors-aliases.spec.js
@@ -18,4 +18,23 @@ describe('Example for using anchors and aliases in YAML documents', () => {
     });
     expect(result).toEqual(referenceSpecification);
   });
+
+  it('should not throw errors that have been cleaned up', () => {
+    expect(() => {
+      swaggerJsdoc({
+        swaggerDefinition: {
+          info: {
+            title: 'Example with anchors and aliases',
+            version: '0.0.1',
+          },
+        },
+        failOnErrors: true,
+        apis: [
+          './examples/yaml-anchors-aliases/x-amazon-apigateway-integrations.yaml',
+          './examples/yaml-anchors-aliases/properties/*.yml',
+          './examples/yaml-anchors-aliases/example.js',
+        ],
+      });
+    }).not.toThrowError();
+  });
 });

--- a/src/specification.js
+++ b/src/specification.js
@@ -281,6 +281,7 @@ function build(options) {
 
     // Format errors into a printable/throwable string
     const errReport = yamlDocsErrors
+      .filter((doc) => doc.errors.length)
       .map(({ errors, filePath }) => {
         let str = `Error in ${filePath} :\n`;
         if (options.verbose) {


### PR DESCRIPTION
Basically just https://github.com/Surnet/swagger-jsdoc/pull/328 but I added the requested test